### PR TITLE
#26: redirected build logs to $job_dir/exaslct.log

### DIFF
--- a/exasol_script_languages_container_tool/cli/commands/build.py
+++ b/exasol_script_languages_container_tool/cli/commands/build.py
@@ -1,3 +1,4 @@
+import sys
 from typing import Tuple
 
 import click
@@ -11,6 +12,7 @@ from exasol_integration_test_docker_environment.cli.options.system_options impor
 from exasol_script_languages_container_tool.cli.options.flavor_options import flavor_options
 from exasol_script_languages_container_tool.cli.options.goal_options import goal_options
 from exasol_script_languages_container_tool.lib.tasks.build.docker_build import DockerBuild
+from exasol_script_languages_container_tool.lib.utils.logging_redirection import create_docker_build_creator
 
 
 @cli.command()
@@ -70,7 +72,9 @@ def build(flavor_path: Tuple[str, ...],
     set_docker_repository_config(target_docker_password, target_docker_repository_name, target_docker_username,
                                  target_docker_tag_prefix, "target")
     set_job_id(DockerBuild.__name__)
-    task_creator = lambda: DockerBuild(flavor_paths=list(flavor_path), goals=list(goal), shortcut_build=shortcut_build)
+    task_creator = create_docker_build_creator(lambda: DockerBuild(flavor_paths=list(flavor_path),
+                                                                   goals=list(goal), shortcut_build=shortcut_build))
+
     success, task = run_task(task_creator, workers, task_dependencies_dot_file)
     if not success:
         exit(1)

--- a/exasol_script_languages_container_tool/lib/utils/logging_redirection.py
+++ b/exasol_script_languages_container_tool/lib/utils/logging_redirection.py
@@ -1,0 +1,17 @@
+import sys
+
+
+def create_docker_build_creator(task_creator):
+    # Provides redirection of ALL logs to exaslct.log in the tasks job directory
+
+    # Parameters:
+    #   task_creator (function): creator function of the task
+    def create_docker_build():
+        task = task_creator()
+        logging_redirection_file = open(f'{task.get_log_path()}/exaslct.log', "w")
+        print(f'Logging to :{logging_redirection_file.name}')
+        sys.stdout = logging_redirection_file
+        sys.stderr = logging_redirection_file
+        return task
+
+    return create_docker_build


### PR DESCRIPTION
Printing logs to the console only has the disadvantages
of analyzing possible issues reported from 3rd party.
Having logs persistently gives the possibility to share the logs
later among  different teams.
For now, only the build logs are redirected, however,
in the future any exaslct command can be easily redirecty,
by encapsulating the creation function of the task with
logging_redirection.create_docker_build_creator()