### PR TITLE
#133: Fixed crash of Python interpreter when executing exaslct commands

### DIFF
--- a/doc/changes/changes_0.11.0.md
+++ b/doc/changes/changes_0.11.0.md
@@ -13,6 +13,7 @@ t.b.d.
 ## Bug Fixes
 
  - #131: Fixed typehint for parameter release_goal in commands
+ - #133: Fixed crash of Python interpreter when executing exaslct commands multiple times
 
 ## Documentation
 

--- a/exasol_script_languages_container_tool/cli/commands/build.py
+++ b/exasol_script_languages_container_tool/cli/commands/build.py
@@ -11,7 +11,7 @@ from exasol_integration_test_docker_environment.cli.options.system_options impor
 from exasol_script_languages_container_tool.cli.options.flavor_options import flavor_options
 from exasol_script_languages_container_tool.cli.options.goal_options import goal_options
 from exasol_script_languages_container_tool.lib.tasks.build.docker_build import DockerBuild
-from exasol_script_languages_container_tool.lib.utils.logging_redirection import Tee
+from exasol_script_languages_container_tool.lib.utils.logging_redirection import TaskLogRedirector
 
 
 @cli.command()
@@ -71,10 +71,10 @@ def build(flavor_path: Tuple[str, ...],
                                  source_docker_tag_prefix, "source")
     set_docker_repository_config(target_docker_password, target_docker_repository_name, target_docker_username,
                                  target_docker_tag_prefix, "target")
-    with Tee.log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=DockerBuild,
-                                                                            flavor_paths=list(flavor_path),
-                                                                            goals=list(goal),
-                                                                            shortcut_build=shortcut_build)) \
+    with TaskLogRedirector.log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=DockerBuild,
+                                                                                          flavor_paths=list(flavor_path),
+                                                                                          goals=list(goal),
+                                                                                          shortcut_build=shortcut_build)) \
             as task_creator:
         success, task = run_task(task_creator, workers, task_dependencies_dot_file)
 

--- a/exasol_script_languages_container_tool/cli/commands/build.py
+++ b/exasol_script_languages_container_tool/cli/commands/build.py
@@ -11,8 +11,7 @@ from exasol_integration_test_docker_environment.cli.options.system_options impor
 from exasol_script_languages_container_tool.cli.options.flavor_options import flavor_options
 from exasol_script_languages_container_tool.cli.options.goal_options import goal_options
 from exasol_script_languages_container_tool.lib.tasks.build.docker_build import DockerBuild
-from exasol_script_languages_container_tool.lib.utils.logging_redirection import log_redirector_task_creator_wrapper, \
-    get_log_path
+from exasol_script_languages_container_tool.lib.utils.logging_redirection import log_redirector_task_creator_wrapper
 
 
 @cli.command()

--- a/exasol_script_languages_container_tool/cli/commands/build.py
+++ b/exasol_script_languages_container_tool/cli/commands/build.py
@@ -11,7 +11,7 @@ from exasol_integration_test_docker_environment.cli.options.system_options impor
 from exasol_script_languages_container_tool.cli.options.flavor_options import flavor_options
 from exasol_script_languages_container_tool.cli.options.goal_options import goal_options
 from exasol_script_languages_container_tool.lib.tasks.build.docker_build import DockerBuild
-from exasol_script_languages_container_tool.lib.utils.logging_redirection import log_redirector_task_creator_wrapper
+from exasol_script_languages_container_tool.lib.utils.logging_redirection import Tee
 
 
 @cli.command()
@@ -58,6 +58,7 @@ def build(flavor_path: Tuple[str, ...],
     instead of building them.
     """
     import_build_steps(flavor_path)
+
     set_build_config(force_rebuild,
                      force_rebuild_from,
                      force_pull,
@@ -70,10 +71,11 @@ def build(flavor_path: Tuple[str, ...],
                                  source_docker_tag_prefix, "source")
     set_docker_repository_config(target_docker_password, target_docker_repository_name, target_docker_username,
                                  target_docker_tag_prefix, "target")
-    with log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=DockerBuild,
-                                                                        flavor_paths=list(flavor_path),
-                                                                        goals=list(goal),
-                                                                        shortcut_build=shortcut_build)) as task_creator:
+    with Tee.log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=DockerBuild,
+                                                                            flavor_paths=list(flavor_path),
+                                                                            goals=list(goal),
+                                                                            shortcut_build=shortcut_build)) \
+            as task_creator:
         success, task = run_task(task_creator, workers, task_dependencies_dot_file)
 
     if not success:

--- a/exasol_script_languages_container_tool/cli/commands/build.py
+++ b/exasol_script_languages_container_tool/cli/commands/build.py
@@ -71,13 +71,11 @@ def build(flavor_path: Tuple[str, ...],
                                  source_docker_tag_prefix, "source")
     set_docker_repository_config(target_docker_password, target_docker_repository_name, target_docker_username,
                                  target_docker_tag_prefix, "target")
-    task_creator = log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=DockerBuild,
-                                                                                  flavor_paths=list(flavor_path),
-                                                                                  goals=list(goal),
-                                                                                  shortcut_build=shortcut_build))
-
-    success, task = run_task(task_creator, workers, task_dependencies_dot_file)
-    print(f'Build log can be found at:{get_log_path(task)}')
+    with log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=DockerBuild,
+                                                                        flavor_paths=list(flavor_path),
+                                                                        goals=list(goal),
+                                                                        shortcut_build=shortcut_build)) as task_creator:
+        success, task = run_task(task_creator, workers, task_dependencies_dot_file)
 
     if not success:
         exit(1)

--- a/exasol_script_languages_container_tool/cli/commands/clean.py
+++ b/exasol_script_languages_container_tool/cli/commands/clean.py
@@ -11,7 +11,7 @@ from exasol_integration_test_docker_environment.cli.options.system_options impor
 from exasol_script_languages_container_tool.cli.options.flavor_options import flavor_options
 from exasol_script_languages_container_tool.lib.tasks.clean.clean_images import CleanExaslcAllImages, \
     CleanExaslcFlavorsImages
-from exasol_script_languages_container_tool.lib.utils.logging_redirection import Tee
+from exasol_script_languages_container_tool.lib.utils.logging_redirection import TaskLogRedirector
 
 
 @cli.command()
@@ -34,7 +34,7 @@ def clean_flavor_images(flavor_path: Tuple[str, ...],
     set_output_directory(output_directory)
     set_docker_repository_config(None, docker_repository_name, None, docker_tag_prefix, "source")
     set_docker_repository_config(None, docker_repository_name, None, docker_tag_prefix, "target")
-    with Tee.log_redirector_task_creator_wrapper(
+    with TaskLogRedirector.log_redirector_task_creator_wrapper(
         lambda: generate_root_task(task_class=CleanExaslcFlavorsImages, flavor_paths=list(flavor_path))) as task_creator:
         success, task = run_task(task_creator, workers, task_dependencies_dot_file)
     if not success:
@@ -59,7 +59,7 @@ def clean_all_images(
     set_output_directory(output_directory)
     set_docker_repository_config(None, docker_repository_name, None, docker_tag_prefix, "source")
     set_docker_repository_config(None, docker_repository_name, None, docker_tag_prefix, "target")
-    with Tee.log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=CleanExaslcAllImages)) as task_creator:
+    with TaskLogRedirector.log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=CleanExaslcAllImages)) as task_creator:
         success, task = run_task(task_creator, workers, task_dependencies_dot_file)
     if not success:
         exit(1)

--- a/exasol_script_languages_container_tool/cli/commands/clean.py
+++ b/exasol_script_languages_container_tool/cli/commands/clean.py
@@ -59,9 +59,8 @@ def clean_all_images(
     set_output_directory(output_directory)
     set_docker_repository_config(None, docker_repository_name, None, docker_tag_prefix, "source")
     set_docker_repository_config(None, docker_repository_name, None, docker_tag_prefix, "target")
-    task_creator = log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=CleanExaslcAllImages))
-    success, task = run_task(task_creator, workers, task_dependencies_dot_file)
-    print(f'Clean log can be found at:{get_log_path(task)}')
+    with log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=CleanExaslcAllImages)) as task_creator:
+        success, task = run_task(task_creator, workers, task_dependencies_dot_file)
     if not success:
         exit(1)
 

--- a/exasol_script_languages_container_tool/cli/commands/clean.py
+++ b/exasol_script_languages_container_tool/cli/commands/clean.py
@@ -35,10 +35,9 @@ def clean_flavor_images(flavor_path: Tuple[str, ...],
     set_output_directory(output_directory)
     set_docker_repository_config(None, docker_repository_name, None, docker_tag_prefix, "source")
     set_docker_repository_config(None, docker_repository_name, None, docker_tag_prefix, "target")
-    task_creator = log_redirector_task_creator_wrapper(
-        lambda: generate_root_task(task_class=CleanExaslcFlavorsImages, flavor_paths=list(flavor_path)))
-    success, task = run_task(task_creator, workers, task_dependencies_dot_file)
-    print(f'Clean flavor images log can be found at:{get_log_path(task)}')
+    with log_redirector_task_creator_wrapper(
+        lambda: generate_root_task(task_class=CleanExaslcFlavorsImages, flavor_paths=list(flavor_path))) as task_creator:
+        success, task = run_task(task_creator, workers, task_dependencies_dot_file)
     if not success:
         exit(1)
 

--- a/exasol_script_languages_container_tool/cli/commands/clean.py
+++ b/exasol_script_languages_container_tool/cli/commands/clean.py
@@ -11,8 +11,7 @@ from exasol_integration_test_docker_environment.cli.options.system_options impor
 from exasol_script_languages_container_tool.cli.options.flavor_options import flavor_options
 from exasol_script_languages_container_tool.lib.tasks.clean.clean_images import CleanExaslcAllImages, \
     CleanExaslcFlavorsImages
-from exasol_script_languages_container_tool.lib.utils.logging_redirection import log_redirector_task_creator_wrapper, \
-    get_log_path
+from exasol_script_languages_container_tool.lib.utils.logging_redirection import log_redirector_task_creator_wrapper
 
 
 @cli.command()

--- a/exasol_script_languages_container_tool/cli/commands/clean.py
+++ b/exasol_script_languages_container_tool/cli/commands/clean.py
@@ -11,7 +11,7 @@ from exasol_integration_test_docker_environment.cli.options.system_options impor
 from exasol_script_languages_container_tool.cli.options.flavor_options import flavor_options
 from exasol_script_languages_container_tool.lib.tasks.clean.clean_images import CleanExaslcAllImages, \
     CleanExaslcFlavorsImages
-from exasol_script_languages_container_tool.lib.utils.logging_redirection import log_redirector_task_creator_wrapper
+from exasol_script_languages_container_tool.lib.utils.logging_redirection import Tee
 
 
 @cli.command()
@@ -34,7 +34,7 @@ def clean_flavor_images(flavor_path: Tuple[str, ...],
     set_output_directory(output_directory)
     set_docker_repository_config(None, docker_repository_name, None, docker_tag_prefix, "source")
     set_docker_repository_config(None, docker_repository_name, None, docker_tag_prefix, "target")
-    with log_redirector_task_creator_wrapper(
+    with Tee.log_redirector_task_creator_wrapper(
         lambda: generate_root_task(task_class=CleanExaslcFlavorsImages, flavor_paths=list(flavor_path))) as task_creator:
         success, task = run_task(task_creator, workers, task_dependencies_dot_file)
     if not success:
@@ -59,7 +59,7 @@ def clean_all_images(
     set_output_directory(output_directory)
     set_docker_repository_config(None, docker_repository_name, None, docker_tag_prefix, "source")
     set_docker_repository_config(None, docker_repository_name, None, docker_tag_prefix, "target")
-    with log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=CleanExaslcAllImages)) as task_creator:
+    with Tee.log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=CleanExaslcAllImages)) as task_creator:
         success, task = run_task(task_creator, workers, task_dependencies_dot_file)
     if not success:
         exit(1)

--- a/exasol_script_languages_container_tool/cli/commands/export.py
+++ b/exasol_script_languages_container_tool/cli/commands/export.py
@@ -11,7 +11,7 @@ from exasol_integration_test_docker_environment.cli.options.system_options impor
 from exasol_script_languages_container_tool.cli.options.flavor_options import flavor_options
 from exasol_script_languages_container_tool.cli.options.goal_options import release_options
 from exasol_script_languages_container_tool.lib.tasks.export.export_containers import ExportContainers
-from exasol_script_languages_container_tool.lib.utils.logging_redirection import Tee
+from exasol_script_languages_container_tool.lib.utils.logging_redirection import TaskLogRedirector
 
 
 @cli.command()
@@ -63,12 +63,12 @@ def export(flavor_path: Tuple[str, ...],
     set_docker_repository_config(target_docker_password, target_docker_repository_name, target_docker_username,
                                  target_docker_tag_prefix, "target")
 
-    with Tee.log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=ExportContainers,
-                                                                            flavor_paths=list(flavor_path),
-                                                                            release_goals=list(release_goal),
-                                                                            export_path=export_path,
-                                                                            release_name=release_name
-                                                                            )) as task_creator:
+    with TaskLogRedirector.log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=ExportContainers,
+                                                                                          flavor_paths=list(flavor_path),
+                                                                                          release_goals=list(release_goal),
+                                                                                          export_path=export_path,
+                                                                                          release_name=release_name
+                                                                                          )) as task_creator:
 
         success, task = run_task(task_creator, workers, task_dependencies_dot_file)
         if success:

--- a/exasol_script_languages_container_tool/cli/commands/export.py
+++ b/exasol_script_languages_container_tool/cli/commands/export.py
@@ -11,7 +11,7 @@ from exasol_integration_test_docker_environment.cli.options.system_options impor
 from exasol_script_languages_container_tool.cli.options.flavor_options import flavor_options
 from exasol_script_languages_container_tool.cli.options.goal_options import release_options
 from exasol_script_languages_container_tool.lib.tasks.export.export_containers import ExportContainers
-from exasol_script_languages_container_tool.lib.utils.logging_redirection import log_redirector_task_creator_wrapper
+from exasol_script_languages_container_tool.lib.utils.logging_redirection import Tee
 
 
 @cli.command()
@@ -63,12 +63,12 @@ def export(flavor_path: Tuple[str, ...],
     set_docker_repository_config(target_docker_password, target_docker_repository_name, target_docker_username,
                                  target_docker_tag_prefix, "target")
 
-    with log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=ExportContainers,
-                                                                                  flavor_paths=list(flavor_path),
-                                                                                  release_goals=list(release_goal),
-                                                                                  export_path=export_path,
-                                                                                  release_name=release_name
-                                                                                  )) as task_creator:
+    with Tee.log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=ExportContainers,
+                                                                            flavor_paths=list(flavor_path),
+                                                                            release_goals=list(release_goal),
+                                                                            export_path=export_path,
+                                                                            release_name=release_name
+                                                                            )) as task_creator:
 
         success, task = run_task(task_creator, workers, task_dependencies_dot_file)
         if success:

--- a/exasol_script_languages_container_tool/cli/commands/export.py
+++ b/exasol_script_languages_container_tool/cli/commands/export.py
@@ -11,8 +11,7 @@ from exasol_integration_test_docker_environment.cli.options.system_options impor
 from exasol_script_languages_container_tool.cli.options.flavor_options import flavor_options
 from exasol_script_languages_container_tool.cli.options.goal_options import release_options
 from exasol_script_languages_container_tool.lib.tasks.export.export_containers import ExportContainers
-from exasol_script_languages_container_tool.lib.utils.logging_redirection import log_redirector_task_creator_wrapper, \
-    get_log_path
+from exasol_script_languages_container_tool.lib.utils.logging_redirection import log_redirector_task_creator_wrapper
 
 
 @cli.command()
@@ -64,18 +63,17 @@ def export(flavor_path: Tuple[str, ...],
     set_docker_repository_config(target_docker_password, target_docker_repository_name, target_docker_username,
                                  target_docker_tag_prefix, "target")
 
-    task_creator = log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=ExportContainers,
+    with log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=ExportContainers,
                                                                                   flavor_paths=list(flavor_path),
                                                                                   release_goals=list(release_goal),
                                                                                   export_path=export_path,
                                                                                   release_name=release_name
-                                                                                  ))
+                                                                                  )) as task_creator:
 
-    success, task = run_task(task_creator, workers, task_dependencies_dot_file)
+        success, task = run_task(task_creator, workers, task_dependencies_dot_file)
+        if success:
+            with task.command_line_output_target.open("r") as f:
+                print(f.read())
 
-    if success:
-        with task.command_line_output_target.open("r") as f:
-            print(f.read())
-    print(f'Export log can be found at:{get_log_path(task)}')
     if not success:
         exit(1)

--- a/exasol_script_languages_container_tool/cli/commands/push.py
+++ b/exasol_script_languages_container_tool/cli/commands/push.py
@@ -11,8 +11,7 @@ from exasol_integration_test_docker_environment.cli.options.system_options impor
 from exasol_script_languages_container_tool.cli.options.flavor_options import flavor_options
 from exasol_script_languages_container_tool.cli.options.goal_options import goal_options
 from exasol_script_languages_container_tool.lib.tasks.push.docker_push import DockerFlavorsPush
-from exasol_script_languages_container_tool.lib.utils.logging_redirection import log_redirector_task_creator_wrapper, \
-    get_log_path
+from exasol_script_languages_container_tool.lib.utils.logging_redirection import log_redirector_task_creator_wrapper
 
 
 @cli.command()
@@ -61,13 +60,13 @@ def push(flavor_path: Tuple[str, ...],
                                  source_docker_tag_prefix, "source")
     set_docker_repository_config(target_docker_password, target_docker_repository_name, target_docker_username,
                                  target_docker_tag_prefix, "target")
-    task_creator = log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=DockerFlavorsPush,
-                                                                                  force_push=force_push,
-                                                                                  push_all=push_all,
-                                                                                  goals=list(goal),
-                                                                                  flavor_paths=list(flavor_path)))
+    with log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=DockerFlavorsPush,
+                                                                        force_push=force_push,
+                                                                        push_all=push_all,
+                                                                        goals=list(goal),
+                                                                        flavor_paths=list(
+                                                                            flavor_path))) as task_creator:
+        success, task = run_task(task_creator, workers, task_dependencies_dot_file)
 
-    success, task = run_task(task_creator, workers, task_dependencies_dot_file)
-    print(f'Push log can be found at:{get_log_path(task)}')
     if not success:
         exit(1)

--- a/exasol_script_languages_container_tool/cli/commands/push.py
+++ b/exasol_script_languages_container_tool/cli/commands/push.py
@@ -11,7 +11,7 @@ from exasol_integration_test_docker_environment.cli.options.system_options impor
 from exasol_script_languages_container_tool.cli.options.flavor_options import flavor_options
 from exasol_script_languages_container_tool.cli.options.goal_options import goal_options
 from exasol_script_languages_container_tool.lib.tasks.push.docker_push import DockerFlavorsPush
-from exasol_script_languages_container_tool.lib.utils.logging_redirection import Tee
+from exasol_script_languages_container_tool.lib.utils.logging_redirection import TaskLogRedirector
 
 
 @cli.command()
@@ -60,11 +60,11 @@ def push(flavor_path: Tuple[str, ...],
                                  source_docker_tag_prefix, "source")
     set_docker_repository_config(target_docker_password, target_docker_repository_name, target_docker_username,
                                  target_docker_tag_prefix, "target")
-    with Tee.log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=DockerFlavorsPush,
-                                                                            force_push=force_push,
-                                                                            push_all=push_all,
-                                                                            goals=list(goal),
-                                                                            flavor_paths=list(
+    with TaskLogRedirector.log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=DockerFlavorsPush,
+                                                                                          force_push=force_push,
+                                                                                          push_all=push_all,
+                                                                                          goals=list(goal),
+                                                                                          flavor_paths=list(
                                                                                 flavor_path))) as task_creator:
         success, task = run_task(task_creator, workers, task_dependencies_dot_file)
 

--- a/exasol_script_languages_container_tool/cli/commands/push.py
+++ b/exasol_script_languages_container_tool/cli/commands/push.py
@@ -11,7 +11,7 @@ from exasol_integration_test_docker_environment.cli.options.system_options impor
 from exasol_script_languages_container_tool.cli.options.flavor_options import flavor_options
 from exasol_script_languages_container_tool.cli.options.goal_options import goal_options
 from exasol_script_languages_container_tool.lib.tasks.push.docker_push import DockerFlavorsPush
-from exasol_script_languages_container_tool.lib.utils.logging_redirection import log_redirector_task_creator_wrapper
+from exasol_script_languages_container_tool.lib.utils.logging_redirection import Tee
 
 
 @cli.command()
@@ -60,12 +60,12 @@ def push(flavor_path: Tuple[str, ...],
                                  source_docker_tag_prefix, "source")
     set_docker_repository_config(target_docker_password, target_docker_repository_name, target_docker_username,
                                  target_docker_tag_prefix, "target")
-    with log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=DockerFlavorsPush,
-                                                                        force_push=force_push,
-                                                                        push_all=push_all,
-                                                                        goals=list(goal),
-                                                                        flavor_paths=list(
-                                                                            flavor_path))) as task_creator:
+    with Tee.log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=DockerFlavorsPush,
+                                                                            force_push=force_push,
+                                                                            push_all=push_all,
+                                                                            goals=list(goal),
+                                                                            flavor_paths=list(
+                                                                                flavor_path))) as task_creator:
         success, task = run_task(task_creator, workers, task_dependencies_dot_file)
 
     if not success:

--- a/exasol_script_languages_container_tool/cli/commands/run_db_tests.py
+++ b/exasol_script_languages_container_tool/cli/commands/run_db_tests.py
@@ -14,7 +14,7 @@ from exasol_integration_test_docker_environment.cli.options.system_options impor
 from exasol_integration_test_docker_environment.cli.options.test_environment_options import test_environment_options, \
     docker_db_options, external_db_options
 from exasol_integration_test_docker_environment.lib.data.environment_type import EnvironmentType
-from exasol_script_languages_container_tool.lib.utils.logging_redirection import log_redirector_task_creator_wrapper
+from exasol_script_languages_container_tool.lib.utils.logging_redirection import Tee
 
 
 @cli.command()
@@ -157,7 +157,7 @@ def run_db_test(flavor_path: Tuple[str, ...],
             handle_commandline_error("Commandline parameter --external-exasol_db-port not set")
         if external_exasol_bucketfs_port is None:
             handle_commandline_error("Commandline parameter --external-exasol-bucketfs-port not set")
-    with log_redirector_task_creator_wrapper(
+    with Tee.log_redirector_task_creator_wrapper(
             lambda: generate_root_task(task_class=TestContainer,
                                        flavor_paths=list(flavor_path),
                                        release_goals=list(release_goal),

--- a/exasol_script_languages_container_tool/cli/commands/run_db_tests.py
+++ b/exasol_script_languages_container_tool/cli/commands/run_db_tests.py
@@ -14,8 +14,7 @@ from exasol_integration_test_docker_environment.cli.options.system_options impor
 from exasol_integration_test_docker_environment.cli.options.test_environment_options import test_environment_options, \
     docker_db_options, external_db_options
 from exasol_integration_test_docker_environment.lib.data.environment_type import EnvironmentType
-from exasol_script_languages_container_tool.lib.utils.logging_redirection import log_redirector_task_creator_wrapper, \
-    get_log_path
+from exasol_script_languages_container_tool.lib.utils.logging_redirection import log_redirector_task_creator_wrapper
 
 
 @cli.command()
@@ -158,8 +157,7 @@ def run_db_test(flavor_path: Tuple[str, ...],
             handle_commandline_error("Commandline parameter --external-exasol_db-port not set")
         if external_exasol_bucketfs_port is None:
             handle_commandline_error("Commandline parameter --external-exasol-bucketfs-port not set")
-    task_creator = \
-        log_redirector_task_creator_wrapper(
+    with log_redirector_task_creator_wrapper(
             lambda: generate_root_task(task_class=TestContainer,
                                        flavor_paths=list(flavor_path),
                                        release_goals=list(release_goal),
@@ -197,14 +195,12 @@ def run_db_test(flavor_path: Tuple[str, ...],
                                        external_exasol_xmlrpc_cluster_name=external_exasol_xmlrpc_cluster_name,
                                        create_certificates=create_certificates
                                        )
-        )
-    success, task = run_task(task_creator, workers, task_dependencies_dot_file)
-
-    print("Test Results:")
-    if task.command_line_output_target.exists():
-        with task.command_line_output_target.open("r") as f:
-            print(f.read())
-    print(f'Test logs can be found at:{get_log_path(task)}')
+        ) as task_creator:
+        success, task = run_task(task_creator, workers, task_dependencies_dot_file)
+        print("Test Results:")
+        if task.command_line_output_target.exists():
+            with task.command_line_output_target.open("r") as f:
+                print(f.read())
     if not success:
         exit(1)
 

--- a/exasol_script_languages_container_tool/cli/commands/run_db_tests.py
+++ b/exasol_script_languages_container_tool/cli/commands/run_db_tests.py
@@ -14,7 +14,7 @@ from exasol_integration_test_docker_environment.cli.options.system_options impor
 from exasol_integration_test_docker_environment.cli.options.test_environment_options import test_environment_options, \
     docker_db_options, external_db_options
 from exasol_integration_test_docker_environment.lib.data.environment_type import EnvironmentType
-from exasol_script_languages_container_tool.lib.utils.logging_redirection import Tee
+from exasol_script_languages_container_tool.lib.utils.logging_redirection import TaskLogRedirector
 
 
 @cli.command()
@@ -157,7 +157,7 @@ def run_db_test(flavor_path: Tuple[str, ...],
             handle_commandline_error("Commandline parameter --external-exasol_db-port not set")
         if external_exasol_bucketfs_port is None:
             handle_commandline_error("Commandline parameter --external-exasol-bucketfs-port not set")
-    with Tee.log_redirector_task_creator_wrapper(
+    with TaskLogRedirector.log_redirector_task_creator_wrapper(
             lambda: generate_root_task(task_class=TestContainer,
                                        flavor_paths=list(flavor_path),
                                        release_goals=list(release_goal),

--- a/exasol_script_languages_container_tool/cli/commands/save.py
+++ b/exasol_script_languages_container_tool/cli/commands/save.py
@@ -11,7 +11,7 @@ from exasol_integration_test_docker_environment.cli.options.system_options impor
 from exasol_script_languages_container_tool.cli.options.flavor_options import flavor_options
 from exasol_script_languages_container_tool.lib.tasks.save.docker_save import DockerSave
 from exasol_script_languages_container_tool.cli.options.goal_options import goal_options
-from exasol_script_languages_container_tool.lib.utils.logging_redirection import Tee
+from exasol_script_languages_container_tool.lib.utils.logging_redirection import TaskLogRedirector
 
 
 @cli.command()
@@ -68,12 +68,12 @@ def save(save_directory: str,
     set_docker_repository_config(target_docker_password, target_docker_repository_name, target_docker_username,
                                  target_docker_tag_prefix, "target")
 
-    with Tee.log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=DockerSave,
-                                                                            save_path=save_directory,
-                                                                            force_save=force_save,
-                                                                            save_all=save_all,
-                                                                            flavor_paths=list(flavor_path),
-                                                                            goals=list(goal))) as task_creator:
+    with TaskLogRedirector.log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=DockerSave,
+                                                                                          save_path=save_directory,
+                                                                                          force_save=force_save,
+                                                                                          save_all=save_all,
+                                                                                          flavor_paths=list(flavor_path),
+                                                                                          goals=list(goal))) as task_creator:
         success, task = run_task(task_creator, workers, task_dependencies_dot_file)
 
     if not success:

--- a/exasol_script_languages_container_tool/cli/commands/save.py
+++ b/exasol_script_languages_container_tool/cli/commands/save.py
@@ -11,7 +11,7 @@ from exasol_integration_test_docker_environment.cli.options.system_options impor
 from exasol_script_languages_container_tool.cli.options.flavor_options import flavor_options
 from exasol_script_languages_container_tool.lib.tasks.save.docker_save import DockerSave
 from exasol_script_languages_container_tool.cli.options.goal_options import goal_options
-from exasol_script_languages_container_tool.lib.utils.logging_redirection import log_redirector_task_creator_wrapper
+from exasol_script_languages_container_tool.lib.utils.logging_redirection import Tee
 
 
 @cli.command()
@@ -68,12 +68,12 @@ def save(save_directory: str,
     set_docker_repository_config(target_docker_password, target_docker_repository_name, target_docker_username,
                                  target_docker_tag_prefix, "target")
 
-    with log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=DockerSave,
-                                                                                  save_path=save_directory,
-                                                                                  force_save=force_save,
-                                                                                  save_all=save_all,
-                                                                                  flavor_paths=list(flavor_path),
-                                                                                  goals=list(goal))) as task_creator:
+    with Tee.log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=DockerSave,
+                                                                            save_path=save_directory,
+                                                                            force_save=force_save,
+                                                                            save_all=save_all,
+                                                                            flavor_paths=list(flavor_path),
+                                                                            goals=list(goal))) as task_creator:
         success, task = run_task(task_creator, workers, task_dependencies_dot_file)
 
     if not success:

--- a/exasol_script_languages_container_tool/cli/commands/save.py
+++ b/exasol_script_languages_container_tool/cli/commands/save.py
@@ -11,8 +11,7 @@ from exasol_integration_test_docker_environment.cli.options.system_options impor
 from exasol_script_languages_container_tool.cli.options.flavor_options import flavor_options
 from exasol_script_languages_container_tool.lib.tasks.save.docker_save import DockerSave
 from exasol_script_languages_container_tool.cli.options.goal_options import goal_options
-from exasol_script_languages_container_tool.lib.utils.logging_redirection import log_redirector_task_creator_wrapper, \
-    get_log_path
+from exasol_script_languages_container_tool.lib.utils.logging_redirection import log_redirector_task_creator_wrapper
 
 
 @cli.command()
@@ -69,13 +68,13 @@ def save(save_directory: str,
     set_docker_repository_config(target_docker_password, target_docker_repository_name, target_docker_username,
                                  target_docker_tag_prefix, "target")
 
-    task_creator = log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=DockerSave,
+    with log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=DockerSave,
                                                                                   save_path=save_directory,
                                                                                   force_save=force_save,
                                                                                   save_all=save_all,
                                                                                   flavor_paths=list(flavor_path),
-                                                                                  goals=list(goal)))
-    success, task = run_task(task_creator, workers, task_dependencies_dot_file)
-    print(f'Save log can be found at:{get_log_path(task)}')
+                                                                                  goals=list(goal))) as task_creator:
+        success, task = run_task(task_creator, workers, task_dependencies_dot_file)
+
     if not success:
         exit(1)

--- a/exasol_script_languages_container_tool/cli/commands/security_scan.py
+++ b/exasol_script_languages_container_tool/cli/commands/security_scan.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 from typing import Tuple
 
@@ -66,6 +67,7 @@ def security_scan(flavor_path: Tuple[str, ...],
         if success:
             with task.security_report_target.open("r") as f:
                 print(f.read())
+    logging.info(f'Full security scan report can be found at:{report_path}')
 
     if not success:
         exit(1)

--- a/exasol_script_languages_container_tool/cli/commands/security_scan.py
+++ b/exasol_script_languages_container_tool/cli/commands/security_scan.py
@@ -19,24 +19,24 @@ from exasol_script_languages_container_tool.lib.utils.logging_redirection import
 @add_options(docker_repository_options)
 @add_options(system_options)
 def security_scan(flavor_path: Tuple[str, ...],
-           force_rebuild: bool,
-           force_rebuild_from: Tuple[str, ...],
-           force_pull: bool,
-           output_directory: str,
-           temporary_base_directory: str,
-           log_build_context_content: bool,
-           cache_directory: str,
-           build_name: str,
-           source_docker_repository_name: str,
-           source_docker_tag_prefix: str,
-           source_docker_username: str,
-           source_docker_password: str,
-           target_docker_repository_name: str,
-           target_docker_tag_prefix: str,
-           target_docker_username: str,
-           target_docker_password: str,
-           workers: int,
-           task_dependencies_dot_file: str):
+                  force_rebuild: bool,
+                  force_rebuild_from: Tuple[str, ...],
+                  force_pull: bool,
+                  output_directory: str,
+                  temporary_base_directory: str,
+                  log_build_context_content: bool,
+                  cache_directory: str,
+                  build_name: str,
+                  source_docker_repository_name: str,
+                  source_docker_tag_prefix: str,
+                  source_docker_username: str,
+                  source_docker_password: str,
+                  target_docker_repository_name: str,
+                  target_docker_tag_prefix: str,
+                  target_docker_username: str,
+                  target_docker_password: str,
+                  workers: int,
+                  task_dependencies_dot_file: str):
     """
     This command executes the security scan, which must be defined as separate step in the build steps declaration.
     The scan runs the docker container of the respective step, passing a folder of the output-dir as argument.
@@ -57,16 +57,15 @@ def security_scan(flavor_path: Tuple[str, ...],
                                  target_docker_tag_prefix, "target")
 
     report_path = Path(output_directory).joinpath("security_scan")
-    task_creator = log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=SecurityScan,
-                                                                                  flavor_paths=list(flavor_path),
-                                                                                  report_path=str(report_path)
-                                                                                  ))
+    with log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=SecurityScan,
+                                                                        flavor_paths=list(flavor_path),
+                                                                        report_path=str(report_path)
+                                                                        )) as task_creator:
+        success, task = run_task(task_creator, workers, task_dependencies_dot_file)
 
-    success, task = run_task(task_creator, workers, task_dependencies_dot_file)
+        if success:
+            with task.security_report_target.open("r") as f:
+                print(f.read())
 
-    if success:
-        with task.security_report_target.open("r") as f:
-            print(f.read())
-    print(f'Full security scan report can be found at:{report_path}')
     if not success:
         exit(1)

--- a/exasol_script_languages_container_tool/cli/commands/security_scan.py
+++ b/exasol_script_languages_container_tool/cli/commands/security_scan.py
@@ -11,7 +11,7 @@ from exasol_integration_test_docker_environment.cli.options.system_options impor
 
 from exasol_script_languages_container_tool.cli.options.flavor_options import flavor_options
 from exasol_script_languages_container_tool.lib.tasks.security_scan.security_scan import SecurityScan
-from exasol_script_languages_container_tool.lib.utils.logging_redirection import Tee
+from exasol_script_languages_container_tool.lib.utils.logging_redirection import TaskLogRedirector
 
 
 @cli.command()
@@ -58,10 +58,10 @@ def security_scan(flavor_path: Tuple[str, ...],
                                  target_docker_tag_prefix, "target")
 
     report_path = Path(output_directory).joinpath("security_scan")
-    with Tee.log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=SecurityScan,
-                                                                            flavor_paths=list(flavor_path),
-                                                                            report_path=str(report_path)
-                                                                            )) as task_creator:
+    with TaskLogRedirector.log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=SecurityScan,
+                                                                                          flavor_paths=list(flavor_path),
+                                                                                          report_path=str(report_path)
+                                                                                          )) as task_creator:
         success, task = run_task(task_creator, workers, task_dependencies_dot_file)
 
         if success:

--- a/exasol_script_languages_container_tool/cli/commands/security_scan.py
+++ b/exasol_script_languages_container_tool/cli/commands/security_scan.py
@@ -10,7 +10,7 @@ from exasol_integration_test_docker_environment.cli.options.system_options impor
 
 from exasol_script_languages_container_tool.cli.options.flavor_options import flavor_options
 from exasol_script_languages_container_tool.lib.tasks.security_scan.security_scan import SecurityScan
-from exasol_script_languages_container_tool.lib.utils.logging_redirection import log_redirector_task_creator_wrapper
+from exasol_script_languages_container_tool.lib.utils.logging_redirection import Tee
 
 
 @cli.command()
@@ -57,10 +57,10 @@ def security_scan(flavor_path: Tuple[str, ...],
                                  target_docker_tag_prefix, "target")
 
     report_path = Path(output_directory).joinpath("security_scan")
-    with log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=SecurityScan,
-                                                                        flavor_paths=list(flavor_path),
-                                                                        report_path=str(report_path)
-                                                                        )) as task_creator:
+    with Tee.log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=SecurityScan,
+                                                                            flavor_paths=list(flavor_path),
+                                                                            report_path=str(report_path)
+                                                                            )) as task_creator:
         success, task = run_task(task_creator, workers, task_dependencies_dot_file)
 
         if success:

--- a/exasol_script_languages_container_tool/cli/commands/upload.py
+++ b/exasol_script_languages_container_tool/cli/commands/upload.py
@@ -11,7 +11,7 @@ from exasol_integration_test_docker_environment.cli.common import add_options, i
 from exasol_integration_test_docker_environment.cli.options.build_options import build_options
 from exasol_integration_test_docker_environment.cli.options.docker_repository_options import docker_repository_options
 from exasol_integration_test_docker_environment.cli.options.system_options import system_options
-from exasol_script_languages_container_tool.lib.utils.logging_redirection import Tee
+from exasol_script_languages_container_tool.lib.utils.logging_redirection import TaskLogRedirector
 
 
 @cli.command()
@@ -81,18 +81,18 @@ def upload(flavor_path: Tuple[str, ...],
         bucketfs_password = getpass.getpass(
             "BucketFS Password for BucketFS %s and User %s:" % (bucketfs_name, bucketfs_username))
 
-    with Tee.log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=UploadContainers,
-                                                                            flavor_paths=list(flavor_path),
-                                                                            release_goals=list(release_goal),
-                                                                            database_host=database_host,
-                                                                            bucketfs_port=bucketfs_port,
-                                                                            bucketfs_username=bucketfs_username,
-                                                                            bucketfs_password=bucketfs_password,
-                                                                            bucket_name=bucket_name,
-                                                                            path_in_bucket=path_in_bucket,
-                                                                            bucketfs_https=bucketfs_https,
-                                                                            release_name=release_name,
-                                                                            bucketfs_name=bucketfs_name)) as task_creator:
+    with TaskLogRedirector.log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=UploadContainers,
+                                                                                          flavor_paths=list(flavor_path),
+                                                                                          release_goals=list(release_goal),
+                                                                                          database_host=database_host,
+                                                                                          bucketfs_port=bucketfs_port,
+                                                                                          bucketfs_username=bucketfs_username,
+                                                                                          bucketfs_password=bucketfs_password,
+                                                                                          bucket_name=bucket_name,
+                                                                                          path_in_bucket=path_in_bucket,
+                                                                                          bucketfs_https=bucketfs_https,
+                                                                                          release_name=release_name,
+                                                                                          bucketfs_name=bucketfs_name)) as task_creator:
 
         success, task = run_task(task_creator, workers, task_dependencies_dot_file)
 

--- a/exasol_script_languages_container_tool/cli/commands/upload.py
+++ b/exasol_script_languages_container_tool/cli/commands/upload.py
@@ -11,8 +11,7 @@ from exasol_integration_test_docker_environment.cli.common import add_options, i
 from exasol_integration_test_docker_environment.cli.options.build_options import build_options
 from exasol_integration_test_docker_environment.cli.options.docker_repository_options import docker_repository_options
 from exasol_integration_test_docker_environment.cli.options.system_options import system_options
-from exasol_script_languages_container_tool.lib.utils.logging_redirection import log_redirector_task_creator_wrapper, \
-    get_log_path
+from exasol_script_languages_container_tool.lib.utils.logging_redirection import log_redirector_task_creator_wrapper
 
 
 @cli.command()
@@ -82,25 +81,24 @@ def upload(flavor_path: Tuple[str, ...],
         bucketfs_password = getpass.getpass(
             "BucketFS Password for BucketFS %s and User %s:" % (bucketfs_name, bucketfs_username))
 
-    task_creator = log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=UploadContainers,
-                                                                                  flavor_paths=list(flavor_path),
-                                                                                  release_goals=list(release_goal),
-                                                                                  database_host=database_host,
-                                                                                  bucketfs_port=bucketfs_port,
-                                                                                  bucketfs_username=bucketfs_username,
-                                                                                  bucketfs_password=bucketfs_password,
-                                                                                  bucket_name=bucket_name,
-                                                                                  path_in_bucket=path_in_bucket,
-                                                                                  bucketfs_https=bucketfs_https,
-                                                                                  release_name=release_name,
-                                                                                  bucketfs_name=bucketfs_name))
+    with log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=UploadContainers,
+                                                                        flavor_paths=list(flavor_path),
+                                                                        release_goals=list(release_goal),
+                                                                        database_host=database_host,
+                                                                        bucketfs_port=bucketfs_port,
+                                                                        bucketfs_username=bucketfs_username,
+                                                                        bucketfs_password=bucketfs_password,
+                                                                        bucket_name=bucket_name,
+                                                                        path_in_bucket=path_in_bucket,
+                                                                        bucketfs_https=bucketfs_https,
+                                                                        release_name=release_name,
+                                                                        bucketfs_name=bucketfs_name)) as task_creator:
 
-    success, task = run_task(task_creator, workers, task_dependencies_dot_file)
+        success, task = run_task(task_creator, workers, task_dependencies_dot_file)
 
-    if success:
-        with task.command_line_output_target.open("r") as f:
-            print(f.read())
-    print(f'Upload log can be found at:{get_log_path(task)}')
+        if success:
+            with task.command_line_output_target.open("r") as f:
+                print(f.read())
 
     if not success:
         exit(1)

--- a/exasol_script_languages_container_tool/cli/commands/upload.py
+++ b/exasol_script_languages_container_tool/cli/commands/upload.py
@@ -11,7 +11,7 @@ from exasol_integration_test_docker_environment.cli.common import add_options, i
 from exasol_integration_test_docker_environment.cli.options.build_options import build_options
 from exasol_integration_test_docker_environment.cli.options.docker_repository_options import docker_repository_options
 from exasol_integration_test_docker_environment.cli.options.system_options import system_options
-from exasol_script_languages_container_tool.lib.utils.logging_redirection import log_redirector_task_creator_wrapper
+from exasol_script_languages_container_tool.lib.utils.logging_redirection import Tee
 
 
 @cli.command()
@@ -81,18 +81,18 @@ def upload(flavor_path: Tuple[str, ...],
         bucketfs_password = getpass.getpass(
             "BucketFS Password for BucketFS %s and User %s:" % (bucketfs_name, bucketfs_username))
 
-    with log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=UploadContainers,
-                                                                        flavor_paths=list(flavor_path),
-                                                                        release_goals=list(release_goal),
-                                                                        database_host=database_host,
-                                                                        bucketfs_port=bucketfs_port,
-                                                                        bucketfs_username=bucketfs_username,
-                                                                        bucketfs_password=bucketfs_password,
-                                                                        bucket_name=bucket_name,
-                                                                        path_in_bucket=path_in_bucket,
-                                                                        bucketfs_https=bucketfs_https,
-                                                                        release_name=release_name,
-                                                                        bucketfs_name=bucketfs_name)) as task_creator:
+    with Tee.log_redirector_task_creator_wrapper(lambda: generate_root_task(task_class=UploadContainers,
+                                                                            flavor_paths=list(flavor_path),
+                                                                            release_goals=list(release_goal),
+                                                                            database_host=database_host,
+                                                                            bucketfs_port=bucketfs_port,
+                                                                            bucketfs_username=bucketfs_username,
+                                                                            bucketfs_password=bucketfs_password,
+                                                                            bucket_name=bucket_name,
+                                                                            path_in_bucket=path_in_bucket,
+                                                                            bucketfs_https=bucketfs_https,
+                                                                            release_name=release_name,
+                                                                            bucketfs_name=bucketfs_name)) as task_creator:
 
         success, task = run_task(task_creator, workers, task_dependencies_dot_file)
 

--- a/exasol_script_languages_container_tool/lib/utils/logging_redirection.py
+++ b/exasol_script_languages_container_tool/lib/utils/logging_redirection.py
@@ -37,7 +37,7 @@ class _Tee(object):
             self.file.write(data)
             self.stdout.write(data)
         else:
-            sys.stdout.write(data)
+            raise RuntimeError("_Tee object used but not initialized.")
 
 
 @contextmanager

--- a/exasol_script_languages_container_tool/lib/utils/logging_redirection.py
+++ b/exasol_script_languages_container_tool/lib/utils/logging_redirection.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 from contextlib import contextmanager
 
@@ -30,7 +31,7 @@ class _Tee(object):
             sys.stdout = self.stdout
             sys.stderr = self.stderr
             self.file.close()
-            print(f'log can be found at:{self.log_file_path}')
+            logging.info(f'Log can be found at:{self.log_file_path}')
 
     def write(self, data):
         if self.is_open:

--- a/exasol_script_languages_container_tool/lib/utils/logging_redirection.py
+++ b/exasol_script_languages_container_tool/lib/utils/logging_redirection.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 from contextlib import contextmanager
+from typing import Optional
 
 from exasol_integration_test_docker_environment.lib.base.base_task import BaseTask
 
@@ -9,52 +10,46 @@ def _get_log_path(task: BaseTask):
     return f'{task.get_log_path()}/exaslct.log'
 
 
-class _Tee(object):
+class Tee(object):
     """
     Helper object which redirects calls to stdout/stderr to itself, prints to a given file and to real stdout/stderr
     """
 
-    def __init__(self):
-        self.is_open = False
-
-    def open(self, task, mode):
+    def __init__(self, task, mode):
         self.log_file_path = _get_log_path(task)
         self.file = open(self.log_file_path, mode)
         self.stdout = sys.stdout
         self.stderr = sys.stderr
         sys.stdout = self
         sys.stderr = self
-        self.is_open = True
 
     def close(self):
-        if self.is_open:
-            sys.stdout = self.stdout
-            sys.stderr = self.stderr
-            self.file.close()
-            logging.info(f'Log can be found at:{self.log_file_path}')
+        sys.stdout = self.stdout
+        sys.stderr = self.stderr
+        self.file.close()
+        logging.info(f'Log can be found at:{self.log_file_path}')
 
     def write(self, data):
-        if self.is_open:
-            self.file.write(data)
-            self.stdout.write(data)
-        else:
-            raise RuntimeError("_Tee object used but not initialized.")
+        self.file.write(data)
+        self.stdout.write(data)
 
+    @classmethod
+    @contextmanager
+    def log_redirector_task_creator_wrapper(cls, task_creator):
+        # Provides redirection of ALL logs to exaslct.log in the tasks job directory
 
-@contextmanager
-def log_redirector_task_creator_wrapper(task_creator):
-    # Provides redirection of ALL logs to exaslct.log in the tasks job directory
+        _tee: Optional[cls] = None
 
-    _tee = _Tee()
+        # Parameters:
+        #   task_creator (function): creator function which creates task
+        def create_task_creator_wrapper():
+            task = task_creator()
+            nonlocal _tee
+            _tee = cls(task, "w")
+            return task
 
-    # Parameters:
-    #   task_creator (function): creator function which creates task
-    def create_task_creator_wrapper():
-        task = task_creator()
-        _tee.open(task, "w")
-        return task
-
-    try:
-        yield create_task_creator_wrapper
-    finally:
-        _tee.close()
+        try:
+            yield create_task_creator_wrapper
+        finally:
+            if _tee is not None:
+                _tee.close()

--- a/exasol_script_languages_container_tool/lib/utils/logging_redirection.py
+++ b/exasol_script_languages_container_tool/lib/utils/logging_redirection.py
@@ -10,7 +10,7 @@ def _get_log_path(task: BaseTask):
     return f'{task.get_log_path()}/exaslct.log'
 
 
-class Tee(object):
+class TaskLogRedirector(object):
     """
     Helper object which redirects calls to stdout/stderr to itself, prints to a given file and to real stdout/stderr
     """

--- a/exasol_script_languages_container_tool/lib/utils/logging_redirection.py
+++ b/exasol_script_languages_container_tool/lib/utils/logging_redirection.py
@@ -1,45 +1,59 @@
 import sys
+from contextlib import contextmanager
 
 from exasol_integration_test_docker_environment.lib.base.base_task import BaseTask
 
 
+def _get_log_path(task: BaseTask):
+    return f'{task.get_log_path()}/exaslct.log'
+
+
 class _Tee(object):
-    # Helper object which redirects calls to stdout/stderr to itself, prints to a given file and to real stdout/stderr
-    def __init__(self, name, mode):
-        self.file = open(name, mode)
+    """
+    Helper object which redirects calls to stdout/stderr to itself, prints to a given file and to real stdout/stderr
+    """
+
+    def __init__(self):
+        self.is_open = False
+
+    def open(self, task, mode):
+        self.log_file_path = _get_log_path(task)
+        self.file = open(self.log_file_path, mode)
         self.stdout = sys.stdout
         self.stderr = sys.stderr
         sys.stdout = self
         sys.stderr = self
+        self.is_open = True
 
-    def get_file(self):
-        return self.file
-
-    def __del__(self):
-        sys.stdout = self.stdout
-        sys.stderr = self.stderr
-        self.file.close()
+    def close(self):
+        if self.is_open:
+            sys.stdout = self.stdout
+            sys.stderr = self.stderr
+            self.file.close()
+            print(f'log can be found at:{self.log_file_path}')
 
     def write(self, data):
-        self.file.write(data)
-        self.stdout.write(data)
+        if self.is_open:
+            self.file.write(data)
+            self.stdout.write(data)
+        else:
+            sys.stdout.write(data)
 
-    def flush(self):
-        self.file.flush()
 
-
+@contextmanager
 def log_redirector_task_creator_wrapper(task_creator):
     # Provides redirection of ALL logs to exaslct.log in the tasks job directory
+
+    _tee = _Tee()
 
     # Parameters:
     #   task_creator (function): creator function which creates task
     def create_task_creator_wrapper():
         task = task_creator()
-        tee = _Tee(get_log_path(task), "w")
+        _tee.open(task, "w")
         return task
 
-    return create_task_creator_wrapper
-
-
-def get_log_path(task: BaseTask):
-    return f'{task.get_log_path()}/exaslct.log'
+    try:
+        yield create_task_creator_wrapper
+    finally:
+        _tee.close()

--- a/test/test_docker_build_direct.py
+++ b/test/test_docker_build_direct.py
@@ -22,9 +22,8 @@ class DockerBuildDirectTest(unittest.TestCase):
     def tearDown(self):
         try:
             self.docker_client.close()
-        except Exception as e:
-            print(e)
-        self._clean_images()
+        finally:
+            self._clean_images()
 
     def _clean_images(self):
         self.runner.invoke(clean_flavor_images,

--- a/test/test_docker_build_direct.py
+++ b/test/test_docker_build_direct.py
@@ -1,0 +1,53 @@
+import unittest
+
+import docker
+from exasol_script_languages_container_tool.cli.commands import build, clean_flavor_images
+
+from exasol_script_languages_container_tool.lib.utils.docker_utils import find_images_by_tag
+from click.testing import CliRunner
+
+import utils as exaslct_utils
+from exasol_integration_test_docker_environment.testing import exaslct_test_environment
+
+
+class DockerBuildDirectTest(unittest.TestCase):
+
+    def setUp(self):
+        print(f"SetUp {self.__class__.__name__}")
+        self.test_environment = exaslct_test_environment.ExaslctTestEnvironment(self, exaslct_utils.EXASLCT_DEFAULT_BIN)
+        self.docker_client = docker.from_env()
+        self.runner = CliRunner()
+        self._clean_images()
+
+    def tearDown(self):
+        try:
+            self.docker_client.close()
+        except Exception as e:
+            print(e)
+        self._clean_images()
+
+    def _clean_images(self):
+        self.runner.invoke(clean_flavor_images,
+                           f"{self.test_environment.flavor_path_argument} "
+                           f"{self.test_environment.clean_docker_repository_arguments}")
+
+    def test_docker_build(self):
+        """
+        Test that executing any exaslct task multiple times within the same Python process,
+        does not have any side effects.
+        """
+
+        for i in range(5):
+            print(f"Execute build run: {i}.")
+            result = self.runner.invoke(build, f"{self.test_environment.flavor_path_argument} "
+                                               f"{self.test_environment.docker_repository_arguments}")
+            assert result.exit_code == 0
+        images = find_images_by_tag(self.docker_client,
+                                    lambda tag: tag.startswith(self.test_environment.repository_name))
+        self.assertTrue(len(images) > 0,
+                        f"Did not found images for repository "
+                        f"{self.test_environment.repository_name} in list {images}")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
RCA:
Log redirection (Tee) was not correctly closed and consecutive assignments of stdout/stderr were not deterministic when calling exaslct multiple times.

Solution:
Close log redirection always (using context manager) after Luigi task finished.