### PR TITLE
#150: Fixed permissions for docker credentials env file

### DIFF
--- a/doc/changes/changes_0.13.0.md
+++ b/doc/changes/changes_0.13.0.md
@@ -13,8 +13,9 @@ t.b.d.
 ## Bug Fixes
 
  - #145: Added explicit dependency to importlib-resources 
- - #144: Added documentation regarding installation of starter scripts and added contributing.md
+ - #150: Fixed permissions for docker credentials env file
 
 ## Documentation
 
+ - #144: Added documentation regarding installation of starter scripts and added contributing.md
  - #147: Improved short help messages

--- a/exasol_script_languages_container_tool/starter_scripts/exaslct_within_docker_container.sh
+++ b/exasol_script_languages_container_tool/starter_scripts/exaslct_within_docker_container.sh
@@ -100,7 +100,7 @@ function create_env_file() {
   if [ -n "${SOURCE_DOCKER_PASSWORD-}" ]; then
     echo "SOURCE_DOCKER_PASSWORD=$SOURCE_DOCKER_PASSWORD" >> "$tmpfile_env"
   fi
-  chmod -w "$tmpfile_env"
+  chmod a-w "$tmpfile_env"
 }
 
 function create_env_file_debug_protected() {

--- a/exasol_script_languages_container_tool/starter_scripts/exaslct_within_docker_container.sh
+++ b/exasol_script_languages_container_tool/starter_scripts/exaslct_within_docker_container.sh
@@ -93,12 +93,14 @@ DOCKER_SOCKET_MOUNT="$HOST_DOCKER_SOCKER_PATH:$CONTAINER_DOCKER_SOCKER_PATH"
 
 function create_env_file() {
   touch "$tmpfile_env"
+  chmod 600 "$tmpfile_env"
   if [ -n "${TARGET_DOCKER_PASSWORD-}" ]; then
     echo "TARGET_DOCKER_PASSWORD=$TARGET_DOCKER_PASSWORD" >> "$tmpfile_env"
   fi
   if [ -n "${SOURCE_DOCKER_PASSWORD-}" ]; then
     echo "SOURCE_DOCKER_PASSWORD=$SOURCE_DOCKER_PASSWORD" >> "$tmpfile_env"
   fi
+  chmod -w "$tmpfile_env"
 }
 
 function create_env_file_debug_protected() {
@@ -116,8 +118,6 @@ function create_env_file_debug_protected() {
   esac
 }
 
-old_umask=$(umask)
-umask 277
 tmpfile_env=$(mktemp)
 trap 'rm -f -- "$tmpfile_env"' INT TERM HUP EXIT
 
@@ -131,4 +131,3 @@ else
   # shellcheck disable=SC2086
   docker run --network host --env-file "$tmpfile_env" --rm $terminal_parameter -v "$PWD:$PWD" -v "$DOCKER_SOCKET_MOUNT" -w "$PWD" "${mount_point_parameter[@]}" "$RUNNER_IMAGE_NAME" bash -c "$RUN_COMMAND"
 fi
-umask "$old_umask"

--- a/exasol_script_languages_container_tool/starter_scripts/exaslct_within_docker_container_slim.sh
+++ b/exasol_script_languages_container_tool/starter_scripts/exaslct_within_docker_container_slim.sh
@@ -46,12 +46,14 @@ DOCKER_SOCKET_MOUNT="$HOST_DOCKER_SOCKER_PATH:$CONTAINER_DOCKER_SOCKER_PATH"
 
 function create_env_file() {
   touch "$tmpfile_env"
+  chmod 600 "$tmpfile_env"
   if [ -n "${TARGET_DOCKER_PASSWORD-}" ]; then
     echo "TARGET_DOCKER_PASSWORD=$TARGET_DOCKER_PASSWORD" >> "$tmpfile_env"
   fi
   if [ -n "${SOURCE_DOCKER_PASSWORD-}" ]; then
     echo "SOURCE_DOCKER_PASSWORD=$SOURCE_DOCKER_PASSWORD" >> "$tmpfile_env"
   fi
+  chmod -w "$tmpfile_env"
 }
 
 function create_env_file_debug_protected() {
@@ -69,8 +71,6 @@ function create_env_file_debug_protected() {
   esac
 }
 
-old_umask=$(umask)
-umask 277
 tmpfile_env=$(mktemp)
 trap 'rm -f -- "$tmpfile_env"' INT TERM HUP EXIT
 
@@ -78,5 +78,3 @@ create_env_file_debug_protected "$tmpfile_env"
 # Ignore shellcheck rule because we want to $terminal_parameter as is
 # shellcheck disable=SC2086
 docker run --network host --env-file "$tmpfile_env" --rm $terminal_parameter -v "$PWD:$PWD" -v "$DOCKER_SOCKET_MOUNT" -w "$PWD" "$RUNNER_IMAGE_NAME" bash -c "$RUN_COMMAND"
-
-umask "$old_umask"

--- a/exasol_script_languages_container_tool/starter_scripts/exaslct_within_docker_container_slim.sh
+++ b/exasol_script_languages_container_tool/starter_scripts/exaslct_within_docker_container_slim.sh
@@ -53,7 +53,7 @@ function create_env_file() {
   if [ -n "${SOURCE_DOCKER_PASSWORD-}" ]; then
     echo "SOURCE_DOCKER_PASSWORD=$SOURCE_DOCKER_PASSWORD" >> "$tmpfile_env"
   fi
-  chmod -w "$tmpfile_env"
+  chmod a-w "$tmpfile_env"
 }
 
 function create_env_file_debug_protected() {


### PR DESCRIPTION
Fixes #150 

Current `umask` prevents write access.
=> Remove usage of `umask` and set file permissions after creation and also after writing credentials (read-only)