### PR TITLE
fixed release_droid_upload_github_release_assets.yml

### DIFF
--- a/.github/workflows/release_droid_upload_github_release_assets.yml
+++ b/.github/workflows/release_droid_upload_github_release_assets.yml
@@ -56,6 +56,7 @@ jobs:
           - 3.8
         test-path: ${{fromJson(needs.prep-testbed.outputs.matrix)}}
     runs-on: ubuntu-latest
+    name: ${{ matrix.test-path.name }}
     steps:
       - uses: actions/checkout@v3
 
@@ -72,7 +73,7 @@ jobs:
         run: ./scripts/test/exaslct_with_poetry.sh --help
 
       - name: Run all tests
-        run: ./scripts/test/run_test.sh ${{ matrix.test-path }}
+        run: ./scripts/test/run_test.sh ${{ matrix.test-path.path }}
         env: # Set the secret as an input
           DOCKER_USER: ${{ secrets.DOCKER_USER }}
           DOCKER_PASSWD: ${{ secrets.DOCKER_PASSWD }}


### PR DESCRIPTION
RCA:
In #163 we changed the format of the return JSON from ./scripts/test/get_all_tests.sh so that it included the name and path as separate items. This new format needs to be applied in release_droid_upload_github_release_assets.yml, too.