### PR TITLE
#218: Added an option to ignore certificate errors for upload command

### DIFF
--- a/doc/changes/changes_1.0.0.md
+++ b/doc/changes/changes_1.0.0.md
@@ -8,7 +8,7 @@ t.b.d.
 
 ## Features
 
-n/a
+#218: Added an option to ignore certificate errors for upload command
 
 ## Refactoring
 

--- a/exasol_script_languages_container_tool/cli/commands/upload.py
+++ b/exasol_script_languages_container_tool/cli/commands/upload.py
@@ -42,7 +42,8 @@ from exasol_script_languages_container_tool.lib import api
 @add_options(docker_repository_options)
 @add_options(system_options)
 @add_options(luigi_logging_options)
-@click.option("--ignore-certificate/--no-ignore-certificate", default=False)
+@click.option("--ssl-cert-path", type=str, default="")
+@click.option("--use-ssl-cert-validation/--no-use-ssl-cert-validation", default=True)
 def upload(
     flavor_path: Tuple[str, ...],
     database_host: str,
@@ -75,7 +76,8 @@ def upload(
     task_dependencies_dot_file: Optional[str],
     log_level: Optional[str],
     use_job_specific_log_file: bool,
-    ignore_certificate: bool,
+    ssl_cert_path: str,
+    use_ssl_cert_validation: bool,
 ):
     """
     This command uploads the whole script-language-container package of the flavor to the database.
@@ -115,7 +117,8 @@ def upload(
             task_dependencies_dot_file=task_dependencies_dot_file,
             log_level=log_level,
             use_job_specific_log_file=use_job_specific_log_file,
-            ignore_certificate=ignore_certificate,
+            ssl_cert_path=ssl_cert_path,
+            use_ssl_cert_validation=use_ssl_cert_validation,
         )
         with result.open("r") as f:
             print(f.read())

--- a/exasol_script_languages_container_tool/cli/commands/upload.py
+++ b/exasol_script_languages_container_tool/cli/commands/upload.py
@@ -42,6 +42,7 @@ from exasol_script_languages_container_tool.lib import api
 @add_options(docker_repository_options)
 @add_options(system_options)
 @add_options(luigi_logging_options)
+@click.option("--ignore-certificate/--no-ignore-certificate", default=False)
 def upload(
     flavor_path: Tuple[str, ...],
     database_host: str,
@@ -74,6 +75,7 @@ def upload(
     task_dependencies_dot_file: Optional[str],
     log_level: Optional[str],
     use_job_specific_log_file: bool,
+    ignore_certificate: bool,
 ):
     """
     This command uploads the whole script-language-container package of the flavor to the database.
@@ -113,6 +115,7 @@ def upload(
             task_dependencies_dot_file=task_dependencies_dot_file,
             log_level=log_level,
             use_job_specific_log_file=use_job_specific_log_file,
+            ignore_certificate=ignore_certificate,
         )
         with result.open("r") as f:
             print(f.read())

--- a/exasol_script_languages_container_tool/lib/api/upload.py
+++ b/exasol_script_languages_container_tool/lib/api/upload.py
@@ -52,7 +52,7 @@ def upload(
     task_dependencies_dot_file: Optional[str] = None,
     log_level: Optional[str] = None,
     use_job_specific_log_file: bool = True,
-    ignore_certificate=False,
+    ignore_certificate: bool = False,
 ) -> luigi.LocalTarget:
     """
     This command uploads the whole script-language-container package of the flavor to the database.

--- a/exasol_script_languages_container_tool/lib/api/upload.py
+++ b/exasol_script_languages_container_tool/lib/api/upload.py
@@ -52,6 +52,7 @@ def upload(
     task_dependencies_dot_file: Optional[str] = None,
     log_level: Optional[str] = None,
     use_job_specific_log_file: bool = True,
+    ignore_certificate=False,
 ) -> luigi.LocalTarget:
     """
     This command uploads the whole script-language-container package of the flavor to the database.
@@ -106,6 +107,7 @@ def upload(
             bucketfs_https=bucketfs_https,
             release_name=release_name,
             bucketfs_name=bucketfs_name,
+            ignore_certificate=ignore_certificate,
         )
 
     return run_task(

--- a/exasol_script_languages_container_tool/lib/api/upload.py
+++ b/exasol_script_languages_container_tool/lib/api/upload.py
@@ -52,7 +52,8 @@ def upload(
     task_dependencies_dot_file: Optional[str] = None,
     log_level: Optional[str] = None,
     use_job_specific_log_file: bool = True,
-    ignore_certificate: bool = False,
+    ssl_cert_path: str = "",
+    use_ssl_cert_validation: bool = True,
 ) -> luigi.LocalTarget:
     """
     This command uploads the whole script-language-container package of the flavor to the database.
@@ -107,7 +108,8 @@ def upload(
             bucketfs_https=bucketfs_https,
             release_name=release_name,
             bucketfs_name=bucketfs_name,
-            ignore_certificate=ignore_certificate,
+            ssl_cert_path=ssl_cert_path,
+            use_ssl_cert_validation=use_ssl_cert_validation,
         )
 
     return run_task(

--- a/exasol_script_languages_container_tool/lib/tasks/upload/upload_container_base_task.py
+++ b/exasol_script_languages_container_tool/lib/tasks/upload/upload_container_base_task.py
@@ -65,7 +65,7 @@ class UploadContainerBaseTask(FlavorBaseTask, UploadContainerParameter):
         command_line_output_str = textwrap.dedent(
             f"""
             Uploaded {release_path} to
-            {self.build_file_path_in_bucket(export_info)}
+            {self.build_file_path_in_bucket(export_info).as_udf_path()}
 
 
             In SQL, you can activate the languages supported by the {flavor_name}

--- a/exasol_script_languages_container_tool/lib/tasks/upload/upload_container_base_task.py
+++ b/exasol_script_languages_container_tool/lib/tasks/upload/upload_container_base_task.py
@@ -1,15 +1,14 @@
 import textwrap
 from pathlib import Path
 
+import exasol.bucketfs as bfs  # type: ignore
 import luigi
-import requests
 from exasol_integration_test_docker_environment.abstract_method_exception import (
     AbstractMethodException,
 )
 from exasol_integration_test_docker_environment.lib.base.flavor_task import (
     FlavorBaseTask,
 )
-from requests.auth import HTTPBasicAuth
 
 from exasol_script_languages_container_tool.lib.tasks.export.export_info import (
     ExportInfo,
@@ -66,7 +65,7 @@ class UploadContainerBaseTask(FlavorBaseTask, UploadContainerParameter):
         command_line_output_str = textwrap.dedent(
             f"""
             Uploaded {release_path} to
-            {self._get_upload_url(export_info, without_login=True)}
+            {self.build_file_path_in_bucket(export_info)}
 
 
             In SQL, you can activate the languages supported by the {flavor_name}
@@ -85,34 +84,30 @@ class UploadContainerBaseTask(FlavorBaseTask, UploadContainerParameter):
         )
         return command_line_output_str
 
-    def _upload_container(self, release_info: ExportInfo):
-        s = requests.session()
-        url = self._get_upload_url(release_info, without_login=True)
-        self.logger.info(f"Upload {release_info.cache_file} to {url}")
-        with open(release_info.cache_file, "rb") as file:
-            response = s.put(url, data=file, auth=self._create_auth_object())
-            response.raise_for_status()
+    def build_file_path_in_bucket(self, release_info: ExportInfo) -> bfs.path.PathLike:
+        backend = bfs.path.StorageBackend.onprem
 
-    def _create_auth_object(self) -> HTTPBasicAuth:
-        auth = HTTPBasicAuth(self.bucketfs_username, self.bucketfs_password)
-        return auth
-
-    def _get_upload_url(self, release_info: ExportInfo, without_login: bool = False):
         complete_release_name = self._get_complete_release_name(release_info)
-        if without_login:
-            login = ""
-        else:
-            login = f"""{self.bucketfs_username}:{self.bucketfs_password}@"""
-        path_in_bucket = (
-            f"{self.path_in_bucket}/" if self.path_in_bucket not in [None, ""] else ""
-        )
-        url = (
-            f"""{self._get_url_prefix()}{login}"""
-            + f"""{self.database_host}:{self.bucketfs_port}/{self.bucket_name}/{path_in_bucket}"""
-            + complete_release_name
-            + ".tar.gz"
-        )
-        return url
+        kwargs = {
+            "backend": backend,
+            "url": f"{self._get_url_prefix()}{self.database_host}:{self.bucketfs_port}",
+            "bucket_name": self.bucket_name,
+            "service_name": self.bucketfs_name,
+            "username": self.bucketfs_username,
+            "password": self.bucketfs_password,
+            "verify": not self.ignore_certificate,
+        }
+        if self.path_in_bucket:
+            kwargs.update({"path": self.path_in_bucket})
+
+        path_in_bucket_to_upload_path = bfs.path.build_path(**kwargs)
+        return path_in_bucket_to_upload_path / f"{complete_release_name}.tar.gz"
+
+    def _upload_container(self, release_info: ExportInfo):
+        bucket_path = self.build_file_path_in_bucket(release_info)
+        self.logger.info(f"Upload {release_info.cache_file} to {bucket_path}")
+        with open(release_info.cache_file, "rb") as file:
+            bucket_path.write(file)
 
     def _get_complete_release_name(self, release_info: ExportInfo):
         complete_release_name = f"""{release_info.name}-{release_info.release_goal}-{self._get_release_name(

--- a/exasol_script_languages_container_tool/lib/tasks/upload/upload_container_base_task.py
+++ b/exasol_script_languages_container_tool/lib/tasks/upload/upload_container_base_task.py
@@ -62,14 +62,9 @@ class UploadContainerBaseTask(FlavorBaseTask, UploadContainerParameter):
             release_path = Path(export_info.cache_file).relative_to(Path("").absolute())
         except ValueError:
             release_path = Path(export_info.cache_file)
-        path_in_bucket = (
-            f"{self.path_in_bucket}/" if self.path_in_bucket not in [None, ""] else ""
-        )
         command_line_output_str = textwrap.dedent(
             f"""
-            Uploaded {release_path} to
-            {self._url}/{self.bucket_name}/{path_in_bucket}{self._get_complete_release_name(export_info)}.tar.gz
-
+            Uploaded {release_path} to {self._complete_url(export_info)}
 
             In SQL, you can activate the languages supported by the {flavor_name}
             flavor by using the following statements:
@@ -108,9 +103,17 @@ class UploadContainerBaseTask(FlavorBaseTask, UploadContainerParameter):
     def _url(self) -> str:
         return f"{self._get_url_prefix()}{self.database_host}:{self.bucketfs_port}"
 
+    def _complete_url(self, export_info: ExportInfo):
+        path_in_bucket = (
+            f"{self.path_in_bucket}/" if self.path_in_bucket not in [None, ""] else ""
+        )
+        return f"{self._url}/{self.bucket_name}/{path_in_bucket}{self._get_complete_release_name(export_info)}.tar.gz"
+
     def _upload_container(self, release_info: ExportInfo):
         bucket_path = self.build_file_path_in_bucket(release_info)
-        self.logger.info(f"Upload {release_info.cache_file} to {bucket_path}")
+        self.logger.info(
+            f"Upload {release_info.cache_file} to {self._complete_url(release_info)}"
+        )
         with open(release_info.cache_file, "rb") as file:
             bucket_path.write(file)
 

--- a/exasol_script_languages_container_tool/lib/tasks/upload/upload_container_parameter.py
+++ b/exasol_script_languages_container_tool/lib/tasks/upload/upload_container_parameter.py
@@ -16,4 +16,5 @@ class UploadContainerParameter:
     path_in_bucket = luigi.OptionalParameter()
     bucketfs_https = luigi.BoolParameter(False)
     release_name = luigi.OptionalParameter()
-    ignore_certificate = luigi.BoolParameter(False)
+    ssl_cert_path = luigi.Parameter()
+    use_ssl_cert_validation = luigi.BoolParameter(True)

--- a/exasol_script_languages_container_tool/lib/tasks/upload/upload_container_parameter.py
+++ b/exasol_script_languages_container_tool/lib/tasks/upload/upload_container_parameter.py
@@ -16,3 +16,4 @@ class UploadContainerParameter:
     path_in_bucket = luigi.OptionalParameter()
     bucketfs_https = luigi.BoolParameter(False)
     release_name = luigi.OptionalParameter()
+    ignore_certificate = luigi.BoolParameter(False)

--- a/poetry.lock
+++ b/poetry.lock
@@ -923,13 +923,13 @@ trio = ["trio (>=0.22.0,<0.26.0)"]
 
 [[package]]
 name = "httpx"
-version = "0.27.0"
+version = "0.27.2"
 description = "The next generation HTTP client."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "httpx-0.27.0-py3-none-any.whl", hash = "sha256:71d5465162c13681bff01ad59b2cc68dd838ea1f10e51574bac27103f00c91a5"},
-    {file = "httpx-0.27.0.tar.gz", hash = "sha256:a0cb88a46f32dc874e04ee956e4c2764aba2aa228f650b06788ba6bda2962ab5"},
+    {file = "httpx-0.27.2-py3-none-any.whl", hash = "sha256:7bb2708e112d8fdd7829cd4243970f0c223274051cb35ee80c03301ee29a3df0"},
+    {file = "httpx-0.27.2.tar.gz", hash = "sha256:f7c2be1d2f3c3c3160d441802406b206c2b76f5947b11115e6df10c6c65e66c2"},
 ]
 
 [package.dependencies]
@@ -944,6 +944,7 @@ brotli = ["brotli", "brotlicffi"]
 cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (==1.*)"]
+zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "humanfriendly"
@@ -1885,13 +1886,13 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "rich"
-version = "13.7.1"
+version = "13.8.0"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
 optional = false
 python-versions = ">=3.7.0"
 files = [
-    {file = "rich-13.7.1-py3-none-any.whl", hash = "sha256:4edbae314f59eb482f54e9e30bf00d33350aaa94f4bfcd4e9e3110e64d0d7222"},
-    {file = "rich-13.7.1.tar.gz", hash = "sha256:9be308cb1fe2f1f57d67ce99e95af38a1e2bc71ad9813b0e247cf7ffbcc3a432"},
+    {file = "rich-13.8.0-py3-none-any.whl", hash = "sha256:2e85306a063b9492dffc86278197a60cbece75bcb766022f3436f567cae11bdc"},
+    {file = "rich-13.8.0.tar.gz", hash = "sha256:a5ac1f1cd448ade0d59cc3356f7db7a7ccda2c8cbae9c7a90c28ff463d3e91f4"},
 ]
 
 [package.dependencies]
@@ -1930,13 +1931,13 @@ files = [
 
 [[package]]
 name = "shibuya"
-version = "2024.8.26"
+version = "2024.8.27"
 description = "A clean, responsive, and customizable Sphinx documentation theme with light/dark mode."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "shibuya-2024.8.26-py3-none-any.whl", hash = "sha256:048f19152fbac98a1cf6ee1cf40adeb4c14e8af073073eee5e6e357bc1487e4a"},
-    {file = "shibuya-2024.8.26.tar.gz", hash = "sha256:49029bbaf1a7ce87a7494175504da6e9b1bdde646876af9cc73e2495839ca829"},
+    {file = "shibuya-2024.8.27-py3-none-any.whl", hash = "sha256:cd227358a54e645ea70de1f79ee85f7d7f5f766cfb61ccb6f23b241fc9597a6c"},
+    {file = "shibuya-2024.8.27.tar.gz", hash = "sha256:fdbd2513636d20ef5b8b6b750d61bd96e31cc5673b08564959b2df862570bd15"},
 ]
 
 [package.dependencies]
@@ -2570,20 +2571,24 @@ files = [
 
 [[package]]
 name = "zipp"
-version = "3.20.0"
+version = "3.20.1"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "zipp-3.20.0-py3-none-any.whl", hash = "sha256:58da6168be89f0be59beb194da1250516fdaa062ccebd30127ac65d30045e10d"},
-    {file = "zipp-3.20.0.tar.gz", hash = "sha256:0145e43d89664cfe1a2e533adc75adafed82fe2da404b4bbb6b026c0157bdb31"},
+    {file = "zipp-3.20.1-py3-none-any.whl", hash = "sha256:9960cd8967c8f85a56f920d5d507274e74f9ff813a0ab8889a5b5be2daf44064"},
+    {file = "zipp-3.20.1.tar.gz", hash = "sha256:c22b14cc4763c5a5b04134207736c107db42e9d3ef2d9779d465f5f1bcba572b"},
 ]
 
 [package.extras]
+check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
+cover = ["pytest-cov"]
 doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-itertools", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy", "pytest-ruff (>=0.2.1)"]
+enabler = ["pytest-enabler (>=2.2)"]
+test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-itertools", "pytest (>=6,!=8.1.*)", "pytest-ignore-flaky"]
+type = ["pytest-mypy"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4"
-content-hash = "de54ad87198b1be62b090f07425f3343a8ce741a2556523e2a88121c0cbaf51f"
+content-hash = "3602b6be3165e9dcb3f3fc2701add89c2701df5e26ee6bdd23542ecda0c0118c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ importlib_metadata = ">=4.6.0"
 importlib-resources = ">=6.4.0"
 networkx = "^3.3.0"
 exasol-integration-test-docker-environment = "^3.1.0"
-requests="^2.31.0"
 exasol-bucketfs="^0.13.0"
 
 [build-system]


### PR DESCRIPTION
fixes #218

1. Added a new parameter `ignore_certificate`
2. Replaced implementation in `upload_container_base_task` to use new BucketFS API