### PR TITLE
Feature/277 add option to export slc to uncompressed tar

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -47,6 +47,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
           poetry-version: 2.1.2
 
+      - name: Run Unit tests
+        run: poetry run nox -s test:unit
+
       - name: Run lint
         run: poetry run nox -s lint:code
 

--- a/exasol/slc/api/deploy.py
+++ b/exasol/slc/api/deploy.py
@@ -61,6 +61,7 @@ def deploy(
     task_dependencies_dot_file: Optional[str] = None,
     log_level: Optional[str] = None,
     use_job_specific_log_file: bool = True,
+    compression: bool = True,
 ) -> Dict[str, Dict[str, DeployResult]]:
     """
     This command uploads the whole script-language-container package of the flavor to the database.
@@ -118,6 +119,7 @@ def deploy(
             bucketfs_name=bucketfs_name,
             ssl_cert_path=ssl_cert_path,
             use_ssl_cert_validation=use_ssl_cert_validation,
+            compression=compression,
         )
 
     deploy_infos = run_task(

--- a/exasol/slc/api/deploy.py
+++ b/exasol/slc/api/deploy.py
@@ -23,6 +23,10 @@ from exasol_integration_test_docker_environment.lib.utils.api_function_decorator
 
 from exasol.slc.internal.tasks.upload.deploy_containers import DeployContainers
 from exasol.slc.internal.tasks.upload.deploy_info import toDeployResult
+from exasol.slc.models.compression_strategy import (
+    CompressionStrategy,
+    defaultCompressionStrategy,
+)
 from exasol.slc.models.deploy_result import DeployResult
 
 
@@ -61,7 +65,7 @@ def deploy(
     task_dependencies_dot_file: Optional[str] = None,
     log_level: Optional[str] = None,
     use_job_specific_log_file: bool = True,
-    compression: bool = True,
+    compression_strategy: CompressionStrategy = defaultCompressionStrategy(),
 ) -> Dict[str, Dict[str, DeployResult]]:
     """
     This command uploads the whole script-language-container package of the flavor to the database.
@@ -119,7 +123,7 @@ def deploy(
             bucketfs_name=bucketfs_name,
             ssl_cert_path=ssl_cert_path,
             use_ssl_cert_validation=use_ssl_cert_validation,
-            compression=compression,
+            compression_strategy=compression_strategy,
         )
 
     deploy_infos = run_task(

--- a/exasol/slc/api/export.py
+++ b/exasol/slc/api/export.py
@@ -51,6 +51,7 @@ def export(
     log_level: Optional[str] = None,
     use_job_specific_log_file: bool = True,
     cleanup_docker_images: bool = False,
+    compression: bool = True,
 ) -> ExportContainerResult:
     """
     This command exports the whole script-language-container package of the flavor,
@@ -93,6 +94,7 @@ def export(
             export_path=export_path,
             release_name=release_name,
             cleanup_docker_images=cleanup_docker_images,
+            compression=compression,
         )
 
     return run_task(

--- a/exasol/slc/api/export.py
+++ b/exasol/slc/api/export.py
@@ -21,6 +21,10 @@ from exasol_integration_test_docker_environment.lib.utils.api_function_decorator
 )
 
 from exasol.slc.internal.tasks.export.export_containers import ExportContainers
+from exasol.slc.models.compression_strategy import (
+    CompressionStrategy,
+    defaultCompressionStrategy,
+)
 from exasol.slc.models.export_container_result import ExportContainerResult
 
 
@@ -51,7 +55,7 @@ def export(
     log_level: Optional[str] = None,
     use_job_specific_log_file: bool = True,
     cleanup_docker_images: bool = False,
-    compression: bool = True,
+    compression_strategy: CompressionStrategy = defaultCompressionStrategy(),
 ) -> ExportContainerResult:
     """
     This command exports the whole script-language-container package of the flavor,
@@ -94,7 +98,7 @@ def export(
             export_path=export_path,
             release_name=release_name,
             cleanup_docker_images=cleanup_docker_images,
-            compression=compression,
+            compression_strategy=compression_strategy,
         )
 
     return run_task(

--- a/exasol/slc/api/run_db_tests.py
+++ b/exasol/slc/api/run_db_tests.py
@@ -147,6 +147,8 @@ def run_db_test(
             raise api_errors.MissingArgumentError("external_exasol_db_port")
         if external_exasol_bucketfs_port is None:
             raise api_errors.MissingArgumentError("external_exasol_bucketfs_port")
+        if external_exasol_ssh_port is None:
+            raise api_errors.MissingArgumentError("external_exasol_ssh_port")
 
     def root_task_generator() -> DependencyLoggerBaseTask:
         return generate_root_task(

--- a/exasol/slc/api/run_db_tests.py
+++ b/exasol/slc/api/run_db_tests.py
@@ -97,6 +97,7 @@ def run_db_test(
     task_dependencies_dot_file: Optional[str] = None,
     log_level: Optional[str] = None,
     use_job_specific_log_file: bool = True,
+    compression: bool = True,
 ) -> AllTestsResult:
     """
     This command runs the integration tests in local docker-db.
@@ -190,6 +191,7 @@ def run_db_test(
             create_certificates=create_certificates,
             additional_db_parameter=additional_db_parameter,
             test_container_content=build_test_container_content(test_container_folder),
+            compression=compression,
         )
 
     return run_task(

--- a/exasol/slc/api/run_db_tests.py
+++ b/exasol/slc/api/run_db_tests.py
@@ -35,6 +35,10 @@ from exasol.slc.internal.tasks.test.test_container import TestContainer
 from exasol.slc.internal.tasks.test.test_container_content import (
     build_test_container_content,
 )
+from exasol.slc.models.compression_strategy import (
+    CompressionStrategy,
+    defaultCompressionStrategy,
+)
 from exasol.slc.models.test_result import AllTestsResult
 
 
@@ -97,7 +101,7 @@ def run_db_test(
     task_dependencies_dot_file: Optional[str] = None,
     log_level: Optional[str] = None,
     use_job_specific_log_file: bool = True,
-    compression: bool = True,
+    compression_strategy: CompressionStrategy = defaultCompressionStrategy(),
 ) -> AllTestsResult:
     """
     This command runs the integration tests in local docker-db.
@@ -193,7 +197,7 @@ def run_db_test(
             create_certificates=create_certificates,
             additional_db_parameter=additional_db_parameter,
             test_container_content=build_test_container_content(test_container_folder),
-            compression=compression,
+            compression_strategy=compression_strategy,
         )
 
     return run_task(

--- a/exasol/slc/api/upload.py
+++ b/exasol/slc/api/upload.py
@@ -61,6 +61,7 @@ def upload(
     use_job_specific_log_file: bool = True,
     ssl_cert_path: str = "",
     use_ssl_cert_validation: bool = True,
+    compression: bool = True,
 ) -> luigi.LocalTarget:
     warnings.warn(
         "The 'upload' function is deprecated, use 'deploy' instead", DeprecationWarning
@@ -113,6 +114,7 @@ def upload(
             bucketfs_name=bucketfs_name,
             ssl_cert_path=ssl_cert_path,
             use_ssl_cert_validation=use_ssl_cert_validation,
+            compression=compression,
         )
 
     return run_task(

--- a/exasol/slc/api/upload.py
+++ b/exasol/slc/api/upload.py
@@ -24,6 +24,10 @@ from exasol_integration_test_docker_environment.lib.utils.api_function_decorator
 )
 
 from exasol.slc.internal.tasks.upload.upload_containers import UploadContainers
+from exasol.slc.models.compression_strategy import (
+    CompressionStrategy,
+    defaultCompressionStrategy,
+)
 
 
 @cli_function
@@ -61,7 +65,7 @@ def upload(
     use_job_specific_log_file: bool = True,
     ssl_cert_path: str = "",
     use_ssl_cert_validation: bool = True,
-    compression: bool = True,
+    compression_strategy: CompressionStrategy = defaultCompressionStrategy(),
 ) -> luigi.LocalTarget:
     warnings.warn(
         "The 'upload' function is deprecated, use 'deploy' instead", DeprecationWarning
@@ -114,7 +118,7 @@ def upload(
             bucketfs_name=bucketfs_name,
             ssl_cert_path=ssl_cert_path,
             use_ssl_cert_validation=use_ssl_cert_validation,
-            compression=compression,
+            compression_strategy=compression_strategy,
         )
 
     return run_task(

--- a/exasol/slc/internal/tasks/export/export_container_base_task.py
+++ b/exasol/slc/internal/tasks/export/export_container_base_task.py
@@ -112,7 +112,7 @@ class ExportContainerBaseTask(FlavorBaseTask, ExportContainerParameter):
         )
         return export_info
 
-    def _get_export_file_suffix(self) -> str:
+    def _get_export_file_extension(self) -> str:
         return ".tar.gz" if self.compression else ".tar"
 
     def _get_cache_file_path(
@@ -124,6 +124,6 @@ class ExportContainerBaseTask(FlavorBaseTask, ExportContainerParameter):
         export_path = Path(export_directory_future.get_output()).absolute()
         release_complete_name = f"""{image_info_of_release_image.target_tag}-{image_info_of_release_image.hash}"""
         cache_file = Path(
-            export_path, release_complete_name + self._get_export_file_suffix()
+            export_path, release_complete_name + self._get_export_file_extension()
         ).absolute()
         return str(cache_file), release_complete_name, release_image_name

--- a/exasol/slc/internal/tasks/export/export_container_base_task.py
+++ b/exasol/slc/internal/tasks/export/export_container_base_task.py
@@ -26,6 +26,7 @@ from exasol.slc.internal.tasks.export.export_container_to_file_task import (
 from exasol.slc.internal.tasks.export.remove_cached_export_file_task import (
     RemoveCachedExportTask,
 )
+from exasol.slc.models.compression_strategy import CompressionStrategy
 from exasol.slc.models.export_info import ExportInfo
 
 
@@ -113,7 +114,14 @@ class ExportContainerBaseTask(FlavorBaseTask, ExportContainerParameter):
         return export_info
 
     def _get_export_file_extension(self) -> str:
-        return ".tar.gz" if self.compression else ".tar"
+        if self.compression_strategy == CompressionStrategy.GZIP:
+            return ".tar.gz"
+        elif self.compression_strategy == CompressionStrategy.NONE:
+            return ".tar"
+        else:
+            raise ValueError(
+                f"Unsupported compression_strategy: {self.compression_strategy}"
+            )
 
     def _get_cache_file_path(
         self,

--- a/exasol/slc/internal/tasks/export/export_container_base_task.py
+++ b/exasol/slc/internal/tasks/export/export_container_base_task.py
@@ -112,6 +112,9 @@ class ExportContainerBaseTask(FlavorBaseTask, ExportContainerParameter):
         )
         return export_info
 
+    def _get_export_file_suffix(self) -> str:
+        return ".tar.gz" if self.compression else ".tar"
+
     def _get_cache_file_path(
         self,
         image_info_of_release_image: ImageInfo,
@@ -120,5 +123,7 @@ class ExportContainerBaseTask(FlavorBaseTask, ExportContainerParameter):
         release_image_name = image_info_of_release_image.get_target_complete_name()
         export_path = Path(export_directory_future.get_output()).absolute()
         release_complete_name = f"""{image_info_of_release_image.target_tag}-{image_info_of_release_image.hash}"""
-        cache_file = Path(export_path, release_complete_name + ".tar.gz").absolute()
+        cache_file = Path(
+            export_path, release_complete_name + self._get_export_file_suffix()
+        ).absolute()
         return str(cache_file), release_complete_name, release_image_name

--- a/exasol/slc/internal/tasks/export/export_container_parameters.py
+++ b/exasol/slc/internal/tasks/export/export_container_parameters.py
@@ -10,6 +10,7 @@ class ExportContainerParameterBase(Config):
     export_path: Optional[str] = luigi.OptionalParameter(None)  # type: ignore
     release_name: Optional[str] = luigi.OptionalParameter(None)  # type: ignore
     cleanup_docker_images: bool = luigi.BoolParameter(False)  # type: ignore
+    compression: bool = luigi.BoolParameter(True)  # type: ignore
 
 
 class ExportContainerParameter(ExportContainerParameterBase):

--- a/exasol/slc/internal/tasks/export/export_container_parameters.py
+++ b/exasol/slc/internal/tasks/export/export_container_parameters.py
@@ -6,11 +6,14 @@ from luigi import Config
 CHECKSUM_ALGORITHM = "sha512sum"
 
 
-class ExportContainerParameterBase(Config):
+class ExportContainerOptionsParameter:
+    compression: bool = luigi.BoolParameter(True)  # type: ignore
+
+
+class ExportContainerParameterBase(ExportContainerOptionsParameter):
     export_path: Optional[str] = luigi.OptionalParameter(None)  # type: ignore
     release_name: Optional[str] = luigi.OptionalParameter(None)  # type: ignore
     cleanup_docker_images: bool = luigi.BoolParameter(False)  # type: ignore
-    compression: bool = luigi.BoolParameter(True)  # type: ignore
 
 
 class ExportContainerParameter(ExportContainerParameterBase):

--- a/exasol/slc/internal/tasks/export/export_container_parameters.py
+++ b/exasol/slc/internal/tasks/export/export_container_parameters.py
@@ -1,13 +1,17 @@
 from typing import Optional, Tuple
 
 import luigi
-from luigi import Config
+
+from exasol.slc.models.compression_strategy import (
+    CompressionStrategy,
+    defaultCompressionStrategy,
+)
 
 CHECKSUM_ALGORITHM = "sha512sum"
 
 
 class ExportContainerOptionsParameter:
-    compression: bool = luigi.BoolParameter(True)  # type: ignore
+    compression_strategy: CompressionStrategy = luigi.EnumParameter(enum=CompressionStrategy, default=defaultCompressionStrategy())  # type: ignore
 
 
 class ExportContainerParameterBase(ExportContainerOptionsParameter):

--- a/exasol/slc/internal/tasks/export/export_container_to_cache_task.py
+++ b/exasol/slc/internal/tasks/export/export_container_to_cache_task.py
@@ -170,11 +170,17 @@ class ExportContainerToCacheTask(
     ) -> None:
         self.logger.info("Pack container file %s", release_file)
         extract_content = " ".join(f"'{file}'" for file in os.listdir(extract_dir))
-        if not str(release_file).endswith("tar.gz"):
+        if str(release_file).endswith("tar.gz"):
+            tmp_release_file = release_file.with_suffix(
+                ""
+            )  # cut off ".gz" from ".tar.gz"
+        elif str(release_file).endswith("tar"):
+            tmp_release_file = release_file
+        else:
             raise ValueError(
-                f"Unexpected release file: '{release_file}'. Expected suffix 'tar.gz'."
+                f"Unexpected release file: '{release_file}'. Expected suffix 'tar.gz' or 'tar'."
             )
-        tmp_release_file = release_file.with_suffix("")  # cut off ".gz" from ".tar.gz"
+
         command = (
             f"""tar -C '{extract_dir}' -vcf '{tmp_release_file}' {extract_content}"""
         )
@@ -195,12 +201,13 @@ class ExportContainerToCacheTask(
             log_path.joinpath("pack_release_file.log"),
         )
         shutil.rmtree(extract_dir)
-        command = f"""gzip {tmp_release_file}"""
-        self.run_command(
-            command,
-            f"Creating '{release_file}'",
-            log_path.joinpath("pack_release_file.log"),
-        )
+        if self.compression:
+            command = f"""gzip {tmp_release_file}"""
+            self.run_command(
+                command,
+                f"Creating '{release_file}'",
+                log_path.joinpath("pack_release_file.log"),
+            )
 
     @staticmethod
     def _modify_extracted_container(extract_dir: str) -> None:

--- a/exasol/slc/internal/tasks/export/export_container_to_cache_task.py
+++ b/exasol/slc/internal/tasks/export/export_container_to_cache_task.py
@@ -36,6 +36,7 @@ from exasol.slc.internal.tasks.export.export_container_parameters import (
     CHECKSUM_ALGORITHM,
     ExportContainerParameter,
 )
+from exasol.slc.models.compression_strategy import CompressionStrategy
 
 
 class CheckCacheFileTask(DependencyLoggerBaseTask):
@@ -178,7 +179,7 @@ class ExportContainerToCacheTask(
             tmp_release_file = release_file
         else:
             raise ValueError(
-                f"Unexpected release file: '{release_file}'. Expected suffix 'tar.gz' or 'tar'."
+                f"Unexpected release file: '{release_file}'. Expected suffix: 'tar.gz' or 'tar'."
             )
 
         command = (
@@ -201,12 +202,18 @@ class ExportContainerToCacheTask(
             log_path.joinpath("pack_release_file.log"),
         )
         shutil.rmtree(extract_dir)
-        if self.compression:
+        if self.compression_strategy == CompressionStrategy.GZIP:
             command = f"""gzip {tmp_release_file}"""
             self.run_command(
                 command,
                 f"Creating '{release_file}'",
                 log_path.joinpath("pack_release_file.log"),
+            )
+        elif self.compression_strategy == CompressionStrategy.NONE:
+            pass
+        else:
+            raise ValueError(
+                f"Unexpected compression_strategy: {self.compression_strategy}"
             )
 
     @staticmethod

--- a/exasol/slc/internal/tasks/export/export_container_to_file_task.py
+++ b/exasol/slc/internal/tasks/export/export_container_to_file_task.py
@@ -57,6 +57,9 @@ class ExportContainerToFileTask(
         )
         self.return_object(export_container_to_file_info)
 
+    def _get_export_file_suffix(self) -> str:
+        return ".tar.gz" if self.compression else ".tar"
+
     def _copy_cache_file_to_output_path(
         self, cache_file: Path, checksum_file: Path, is_new: bool
     ) -> Optional[Path]:
@@ -66,9 +69,7 @@ class ExportContainerToFileTask(
                 suffix = f"""_{self.release_name}"""
             else:
                 suffix = ""
-            file_name = (
-                f"""{self.get_flavor_name()}_{self.release_goal}{suffix}.tar.gz"""
-            )
+            file_name = f"""{self.get_flavor_name()}_{self.release_goal}{suffix}{self._get_export_file_suffix()}"""
             output_file = Path(str(self.export_path), file_name)
             output_checksum_file = Path(
                 str(self.export_path), file_name + "." + CHECKSUM_ALGORITHM

--- a/exasol/slc/internal/tasks/export/export_container_to_file_task.py
+++ b/exasol/slc/internal/tasks/export/export_container_to_file_task.py
@@ -20,6 +20,7 @@ from exasol.slc.internal.tasks.export.export_container_parameters import (
 from exasol.slc.internal.tasks.export.export_container_to_cache_task import (
     ExportContainerToCacheTask,
 )
+from exasol.slc.internal.utils.file_utilities import detect_container_file_extension
 
 
 class ExportContainerToFileInfo(Info):
@@ -57,9 +58,6 @@ class ExportContainerToFileTask(
         )
         self.return_object(export_container_to_file_info)
 
-    def _get_export_file_suffix(self) -> str:
-        return ".tar.gz" if self.compression else ".tar"
-
     def _copy_cache_file_to_output_path(
         self, cache_file: Path, checksum_file: Path, is_new: bool
     ) -> Optional[Path]:
@@ -69,7 +67,8 @@ class ExportContainerToFileTask(
                 suffix = f"""_{self.release_name}"""
             else:
                 suffix = ""
-            file_name = f"""{self.get_flavor_name()}_{self.release_goal}{suffix}{self._get_export_file_suffix()}"""
+            file_extension = detect_container_file_extension(cache_file.name)
+            file_name = f"""{self.get_flavor_name()}_{self.release_goal}{suffix}{file_extension}"""
             output_file = Path(str(self.export_path), file_name)
             output_checksum_file = Path(
                 str(self.export_path), file_name + "." + CHECKSUM_ALGORITHM

--- a/exasol/slc/internal/tasks/test/test_container.py
+++ b/exasol/slc/internal/tasks/test/test_container.py
@@ -13,6 +13,9 @@ from exasol_integration_test_docker_environment.lib.test_environment.parameter.s
     SpawnTestEnvironmentParameter,
 )
 
+from exasol.slc.internal.tasks.export.export_container_parameters import (
+    ExportContainerOptionsParameter,
+)
 from exasol.slc.internal.tasks.test.run_db_tests_parameter import (
     GeneralRunDBTestParameter,
     RunDBTestsInTestConfigParameter,
@@ -30,7 +33,9 @@ STATUS_INDENT = 2
 
 
 class TestContainerParameter(
-    RunDBTestsInTestConfigParameter, GeneralRunDBTestParameter
+    RunDBTestsInTestConfigParameter,
+    GeneralRunDBTestParameter,
+    ExportContainerOptionsParameter,
 ):
     release_goals: Tuple[str, ...] = luigi.ListParameter(["release"])  # type: ignore
     languages: Tuple[Optional[str], ...] = luigi.ListParameter([None])  # type: ignore

--- a/exasol/slc/internal/tasks/test/test_runner_db_test_with_export_task.py
+++ b/exasol/slc/internal/tasks/test/test_runner_db_test_with_export_task.py
@@ -26,7 +26,7 @@ class TestRunnerDBTestWithExportTask(
             ExportFlavorContainer,
             release_goals=[self.release_goal],
             flavor_path=self.flavor_path,
-            compression=self.compression,
+            compression_strategy=self.compression_strategy,
         )
         self._export_infos_future = self.register_dependency(export_container_task)
 

--- a/exasol/slc/internal/tasks/test/test_runner_db_test_with_export_task.py
+++ b/exasol/slc/internal/tasks/test/test_runner_db_test_with_export_task.py
@@ -1,5 +1,8 @@
 from typing import Dict
 
+from exasol.slc.internal.tasks.export.export_container_parameters import (
+    ExportContainerOptionsParameter,
+)
 from exasol.slc.internal.tasks.export.export_containers import ExportFlavorContainer
 from exasol.slc.internal.tasks.test.container_file_under_test_info import (
     ContainerFileUnderTestInfo,
@@ -10,7 +13,9 @@ from exasol.slc.internal.tasks.test.test_runner_db_test_base_task import (
 from exasol.slc.models.export_info import ExportInfo
 
 
-class TestRunnerDBTestWithExportTask(TestRunnerDBTestBaseTask):
+class TestRunnerDBTestWithExportTask(
+    TestRunnerDBTestBaseTask, ExportContainerOptionsParameter
+):
 
     def register_required(self) -> None:
         self.register_export_container()
@@ -21,6 +26,7 @@ class TestRunnerDBTestWithExportTask(TestRunnerDBTestBaseTask):
             ExportFlavorContainer,
             release_goals=[self.release_goal],
             flavor_path=self.flavor_path,
+            compression=self.compression,
         )
         self._export_infos_future = self.register_dependency(export_container_task)
 

--- a/exasol/slc/internal/tasks/test/upload_exported_container.py
+++ b/exasol/slc/internal/tasks/test/upload_exported_container.py
@@ -1,12 +1,7 @@
-from pathlib import Path
-
 import luigi
-from exasol_integration_test_docker_environment.lib.base.json_pickle_parameter import (
-    JsonPickleParameter,
-)
 
 from exasol.slc.internal.tasks.test.upload_file_to_bucket_fs import UploadFileToBucketFS
-from exasol.slc.models.export_info import ExportInfo
+from exasol.slc.internal.utils.file_utilities import detect_container_file_extension
 
 
 class UploadExportedContainer(UploadFileToBucketFS):
@@ -24,7 +19,11 @@ class UploadExportedContainer(UploadFileToBucketFS):
 
     def get_upload_target(self) -> str:
         return (
-            "myudfs/" + self.target_name + ".tar.gz"  # pylint: disable=no-member
+            "myudfs/"
+            + self.target_name
+            + detect_container_file_extension(
+                self.file_to_upload
+            )  # pylint: disable=no-member
         )  # pylint: disable=no-member
 
     def get_sync_time_estimation(self) -> int:

--- a/exasol/slc/internal/tasks/upload/deploy_container_base_task.py
+++ b/exasol/slc/internal/tasks/upload/deploy_container_base_task.py
@@ -24,6 +24,7 @@ from exasol.slc.internal.tasks.upload.language_definition import LanguageDefinit
 from exasol.slc.internal.tasks.upload.upload_container_parameter import (
     UploadContainerParameter,
 )
+from exasol.slc.internal.utils.file_utilities import detect_container_file_extension
 from exasol.slc.models.export_info import ExportInfo
 from exasol.slc.models.language_definition_components import (
     LanguageDefinitionComponents,
@@ -80,6 +81,7 @@ class DeployContainerBaseTask(FlavorBaseTask, UploadContainerParameter):
             complete_release_name=self._get_complete_release_name(export_info),
             human_readable_location=self._complete_url(export_info),
             language_definition_builder=lang_def_builder,
+            file_extension=detect_container_file_extension(path_in_bucket.name),
         )
         self.return_object(result)
 
@@ -98,7 +100,10 @@ class DeployContainerBaseTask(FlavorBaseTask, UploadContainerParameter):
             verify=verify,
             path=self.path_in_bucket or "",
         )
-        return path_in_bucket_to_upload_path / f"{complete_release_name}.tar.gz"
+        return (
+            path_in_bucket_to_upload_path
+            / f"{complete_release_name}{detect_container_file_extension(release_info.cache_file)}"
+        )
 
     @property
     def _url(self) -> str:
@@ -108,7 +113,7 @@ class DeployContainerBaseTask(FlavorBaseTask, UploadContainerParameter):
         path_in_bucket = (
             f"{self.path_in_bucket}/" if self.path_in_bucket not in [None, ""] else ""
         )
-        return f"{self._url}/{self.bucket_name}/{path_in_bucket}{self._get_complete_release_name(export_info)}.tar.gz"
+        return f"{self._url}/{self.bucket_name}/{path_in_bucket}{self._get_complete_release_name(export_info)}{detect_container_file_extension(export_info.cache_file)}"
 
     def _upload_container(self, release_info: ExportInfo) -> bfs.path.PathLike:
         bucket_path = self.build_file_path_in_bucket(release_info)

--- a/exasol/slc/internal/tasks/upload/deploy_info.py
+++ b/exasol/slc/internal/tasks/upload/deploy_info.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 
 import exasol.bucketfs as bfs  # type: ignore
 
+from exasol.slc.internal.utils.file_utilities import detect_container_file_extension
 from exasol.slc.models.deploy_result import DeployResult
 from exasol.slc.models.language_definitions_builder import LanguageDefinitionsBuilder
 
@@ -12,6 +13,7 @@ class DeployInfo:
     complete_release_name: str
     human_readable_location: str
     language_definition_builder: LanguageDefinitionsBuilder
+    file_extension: str
 
 
 def toDeployResult(
@@ -45,7 +47,7 @@ def toDeployResult(
             verify=verify,
             path=path_in_bucket or "",
         )
-        / f"{complete_release_name}.tar.gz"
+        / f"{complete_release_name}{deploy_info.file_extension}"
     )
 
     return DeployResult(

--- a/exasol/slc/internal/tasks/upload/upload_container_base_task.py
+++ b/exasol/slc/internal/tasks/upload/upload_container_base_task.py
@@ -84,6 +84,9 @@ class UploadContainerBaseTask(FlavorBaseTask, UploadContainerParameter):
         )
         return command_line_output_str
 
+    def _get_export_file_suffix(self) -> str:
+        return ".tar.gz" if self.compression else ".tar"
+
     def build_file_path_in_bucket(self, release_info: ExportInfo) -> bfs.path.PathLike:
         backend = bfs.path.StorageBackend.onprem
 
@@ -99,7 +102,10 @@ class UploadContainerBaseTask(FlavorBaseTask, UploadContainerParameter):
             verify=verify,
             path=self.path_in_bucket or "",
         )
-        return path_in_bucket_to_upload_path / f"{complete_release_name}.tar.gz"
+        return (
+            path_in_bucket_to_upload_path
+            / f"{complete_release_name}{self._get_export_file_suffix()}"
+        )
 
     @property
     def _url(self) -> str:
@@ -109,7 +115,7 @@ class UploadContainerBaseTask(FlavorBaseTask, UploadContainerParameter):
         path_in_bucket = (
             f"{self.path_in_bucket}/" if self.path_in_bucket not in [None, ""] else ""
         )
-        return f"{self._url}/{self.bucket_name}/{path_in_bucket}{self._get_complete_release_name(export_info)}.tar.gz"
+        return f"{self._url}/{self.bucket_name}/{path_in_bucket}{self._get_complete_release_name(export_info)}{self._get_export_file_suffix()}"
 
     def _upload_container(self, release_info: ExportInfo):
         bucket_path = self.build_file_path_in_bucket(release_info)

--- a/exasol/slc/internal/tasks/upload/upload_container_parameter.py
+++ b/exasol/slc/internal/tasks/upload/upload_container_parameter.py
@@ -2,8 +2,12 @@ from typing import Optional
 
 import luigi
 
+from exasol.slc.internal.tasks.export.export_container_parameters import (
+    ExportContainerOptionsParameter,
+)
 
-class UploadContainerParameter:
+
+class UploadContainerParameter(ExportContainerOptionsParameter):
     database_host: str = luigi.Parameter()  # type: ignore
     bucketfs_port: int = luigi.IntParameter()  # type: ignore
     bucketfs_username: str = luigi.Parameter(significant=False)  # type: ignore

--- a/exasol/slc/internal/utils/file_utilities.py
+++ b/exasol/slc/internal/utils/file_utilities.py
@@ -1,0 +1,8 @@
+def detect_container_file_extension(source_file: str) -> str:
+    allowed_extensions = [".tar.gz", ".tar"]
+    for suffix in allowed_extensions:
+        if source_file.endswith(suffix):
+            return suffix
+    raise ValueError(
+        f"File {source_file} does not end with one of {allowed_extensions}"
+    )

--- a/exasol/slc/models/compression_strategy.py
+++ b/exasol/slc/models/compression_strategy.py
@@ -1,0 +1,14 @@
+from enum import Enum
+
+
+class CompressionStrategy(Enum):
+    """
+    This enum serves as a definition of values for possible compression strategy of the script-lamnguages-container file.
+    """
+
+    NONE = "none"
+    GZIP = "gzip"
+
+
+def defaultCompressionStrategy() -> CompressionStrategy:
+    return CompressionStrategy.GZIP

--- a/exasol/slc/tool/commands/deploy.py
+++ b/exasol/slc/tool/commands/deploy.py
@@ -21,7 +21,9 @@ from exasol_integration_test_docker_environment.lib.utils.cli_function_decorator
 )
 
 from exasol.slc import api
+from exasol.slc.models.compression_strategy import CompressionStrategy
 from exasol.slc.tool.cli import cli
+from exasol.slc.tool.options.export_options import export_options
 from exasol.slc.tool.options.flavor_options import flavor_options
 from exasol.slc.tool.options.goal_options import release_options
 
@@ -83,6 +85,7 @@ def secret_callback(ctx: click.Context, param: click.Option, value: Any):
 @add_options(docker_repository_options)
 @add_options(system_options)
 @add_options(luigi_logging_options)
+@add_options(export_options)
 def deploy(
     flavor_path: Tuple[str, ...],
     bucketfs_host: str,
@@ -117,6 +120,7 @@ def deploy(
     task_dependencies_dot_file: Optional[str],
     log_level: Optional[str],
     use_job_specific_log_file: bool,
+    compression_strategy: str,
 ):
     """
     This command uploads the whole script-language-container package of the flavor to the database.
@@ -158,6 +162,7 @@ def deploy(
             use_job_specific_log_file=use_job_specific_log_file,
             ssl_cert_path=ssl_cert_path,
             use_ssl_cert_validation=use_ssl_cert_validation,
+            compression_strategy=CompressionStrategy[compression_strategy.upper()],
         )
         for flavor_name, lang_def_builds_per_release in result.items():
             for release, deploy_result in lang_def_builds_per_release.items():

--- a/exasol/slc/tool/commands/export.py
+++ b/exasol/slc/tool/commands/export.py
@@ -19,6 +19,7 @@ from exasol_integration_test_docker_environment.lib.utils.cli_function_decorator
 )
 
 from exasol.slc import api
+from exasol.slc.models.compression_strategy import CompressionStrategy
 from exasol.slc.tool.cli import cli
 from exasol.slc.tool.options.export_options import export_options
 from exasol.slc.tool.options.flavor_options import flavor_options
@@ -73,7 +74,7 @@ def export(
     log_level: Optional[str],
     use_job_specific_log_file: bool,
     cleanup_docker_images: bool,
-    compression: bool,
+    compression_strategy: str,
 ):
     """
     This command exports the whole script-language-container package of the flavor,
@@ -107,7 +108,7 @@ def export(
             log_level=log_level,
             use_job_specific_log_file=use_job_specific_log_file,
             cleanup_docker_images=cleanup_docker_images,
-            compression=compression,
+            compression_strategy=CompressionStrategy[compression_strategy.upper()],
         )
         with open(export_result.command_line_output_path) as f:
             print(f.read())

--- a/exasol/slc/tool/commands/export.py
+++ b/exasol/slc/tool/commands/export.py
@@ -20,6 +20,7 @@ from exasol_integration_test_docker_environment.lib.utils.cli_function_decorator
 
 from exasol.slc import api
 from exasol.slc.tool.cli import cli
+from exasol.slc.tool.options.export_options import export_options
 from exasol.slc.tool.options.flavor_options import flavor_options
 from exasol.slc.tool.options.goal_options import release_options
 
@@ -45,11 +46,7 @@ from exasol.slc.tool.options.goal_options import release_options
     help="Clean up the docker images during the export."
     " This might be helpful to save disk space for large containers.",
 )
-@click.option(
-    "--compression/--no-compression",
-    default=True,
-    help="If set to --compression, a '.tar.gz' file will be created. Otherwise a '.tar' will be created.",
-)
+@add_options(export_options)
 def export(
     flavor_path: Tuple[str, ...],
     release_goal: Tuple[str, ...],

--- a/exasol/slc/tool/commands/export.py
+++ b/exasol/slc/tool/commands/export.py
@@ -45,6 +45,11 @@ from exasol.slc.tool.options.goal_options import release_options
     help="Clean up the docker images during the export."
     " This might be helpful to save disk space for large containers.",
 )
+@click.option(
+    "--compression/--no-compression",
+    default=True,
+    help="If set to --compression, a '.tar.gz' file will be created. Otherwise a '.tar' will be created.",
+)
 def export(
     flavor_path: Tuple[str, ...],
     release_goal: Tuple[str, ...],
@@ -71,6 +76,7 @@ def export(
     log_level: Optional[str],
     use_job_specific_log_file: bool,
     cleanup_docker_images: bool,
+    compression: bool,
 ):
     """
     This command exports the whole script-language-container package of the flavor,
@@ -104,6 +110,7 @@ def export(
             log_level=log_level,
             use_job_specific_log_file=use_job_specific_log_file,
             cleanup_docker_images=cleanup_docker_images,
+            compression=compression,
         )
         with open(export_result.command_line_output_path) as f:
             print(f.read())

--- a/exasol/slc/tool/commands/run_db_tests.py
+++ b/exasol/slc/tool/commands/run_db_tests.py
@@ -26,6 +26,7 @@ from exasol_integration_test_docker_environment.lib.utils.cli_function_decorator
 from exasol.slc import api
 from exasol.slc.api import api_errors
 from exasol.slc.tool.cli import cli
+from exasol.slc.tool.options.export_options import export_options
 from exasol.slc.tool.options.flavor_options import flavor_options
 from exasol.slc.tool.options.goal_options import release_options
 from exasol.slc.tool.options.test_container_options import test_container_options
@@ -146,6 +147,7 @@ from exasol.slc.tool.options.test_container_options import test_container_option
 @add_options(docker_repository_options)
 @add_options(system_options)
 @add_options(luigi_logging_options)
+@add_options(export_options)
 def run_db_test(
     flavor_path: Tuple[str, ...],
     release_goal: Tuple[str, ...],
@@ -204,6 +206,7 @@ def run_db_test(
     task_dependencies_dot_file: Optional[str],
     log_level: Optional[str],
     use_job_specific_log_file: bool,
+    compression: bool,
 ):
     """
     This command runs the integration tests in local docker-db.
@@ -272,6 +275,7 @@ def run_db_test(
                 task_dependencies_dot_file=task_dependencies_dot_file,
                 log_level=log_level,
                 use_job_specific_log_file=use_job_specific_log_file,
+                compression=compression,
             )
             if result.command_line_output_path.exists():
                 with result.command_line_output_path.open("r") as f:

--- a/exasol/slc/tool/commands/run_db_tests.py
+++ b/exasol/slc/tool/commands/run_db_tests.py
@@ -140,7 +140,7 @@ from exasol.slc.tool.options.test_container_options import test_container_option
 @click.option(
     "--use-existing-container",
     type=click.Path(exists=True, file_okay=True, dir_okay=False),
-    help="""Use existing exported container (.tar.gz). The given file must be compatible with the given flavor. """,
+    help="""Use existing exported container (.tar.gz or .tar). The given file must be compatible with the given flavor. """,
 )
 @add_options(test_container_options)
 @add_options(build_options)

--- a/exasol/slc/tool/commands/run_db_tests.py
+++ b/exasol/slc/tool/commands/run_db_tests.py
@@ -25,6 +25,7 @@ from exasol_integration_test_docker_environment.lib.utils.cli_function_decorator
 
 from exasol.slc import api
 from exasol.slc.api import api_errors
+from exasol.slc.models.compression_strategy import CompressionStrategy
 from exasol.slc.tool.cli import cli
 from exasol.slc.tool.options.export_options import export_options
 from exasol.slc.tool.options.flavor_options import flavor_options
@@ -184,7 +185,7 @@ def run_db_test(
     reuse_uploaded_container: bool,
     reuse_test_container: bool,
     reuse_test_environment: bool,
-    use_existing_container: str,
+    use_existing_container: Optional[str],
     test_container_folder: str,
     force_rebuild: bool,
     force_rebuild_from: Tuple[str, ...],
@@ -206,7 +207,7 @@ def run_db_test(
     task_dependencies_dot_file: Optional[str],
     log_level: Optional[str],
     use_job_specific_log_file: bool,
-    compression: bool,
+    compression_strategy: str,
 ):
     """
     This command runs the integration tests in local docker-db.
@@ -275,7 +276,7 @@ def run_db_test(
                 task_dependencies_dot_file=task_dependencies_dot_file,
                 log_level=log_level,
                 use_job_specific_log_file=use_job_specific_log_file,
-                compression=compression,
+                compression_strategy=CompressionStrategy[compression_strategy.upper()],
             )
             if result.command_line_output_path.exists():
                 with result.command_line_output_path.open("r") as f:

--- a/exasol/slc/tool/commands/upload.py
+++ b/exasol/slc/tool/commands/upload.py
@@ -20,7 +20,7 @@ from exasol_integration_test_docker_environment.lib.utils.cli_function_decorator
 
 from exasol.slc import api
 from exasol.slc.tool.cli import cli
-from exasol.slc.tool.options import export_options
+from exasol.slc.tool.options.export_options import export_options
 from exasol.slc.tool.options.flavor_options import flavor_options
 from exasol.slc.tool.options.goal_options import release_options
 

--- a/exasol/slc/tool/commands/upload.py
+++ b/exasol/slc/tool/commands/upload.py
@@ -20,6 +20,7 @@ from exasol_integration_test_docker_environment.lib.utils.cli_function_decorator
 
 from exasol.slc import api
 from exasol.slc.tool.cli import cli
+from exasol.slc.tool.options import export_options
 from exasol.slc.tool.options.flavor_options import flavor_options
 from exasol.slc.tool.options.goal_options import release_options
 
@@ -44,6 +45,7 @@ from exasol.slc.tool.options.goal_options import release_options
 @add_options(luigi_logging_options)
 @click.option("--ssl-cert-path", type=str, default="")
 @click.option("--use-ssl-cert-validation/--no-use-ssl-cert-validation", default=True)
+@add_options(export_options)
 def upload(
     flavor_path: Tuple[str, ...],
     database_host: str,
@@ -78,6 +80,7 @@ def upload(
     use_job_specific_log_file: bool,
     ssl_cert_path: str,
     use_ssl_cert_validation: bool,
+    compression: bool,
 ):
     """
     This command uploads the whole script-language-container package of the flavor to the database.
@@ -120,6 +123,7 @@ def upload(
             use_job_specific_log_file=use_job_specific_log_file,
             ssl_cert_path=ssl_cert_path,
             use_ssl_cert_validation=use_ssl_cert_validation,
+            compression=compression,
         )
         with result.open("r") as f:
             print(f.read())

--- a/exasol/slc/tool/commands/upload.py
+++ b/exasol/slc/tool/commands/upload.py
@@ -19,6 +19,7 @@ from exasol_integration_test_docker_environment.lib.utils.cli_function_decorator
 )
 
 from exasol.slc import api
+from exasol.slc.models.compression_strategy import CompressionStrategy
 from exasol.slc.tool.cli import cli
 from exasol.slc.tool.options.export_options import export_options
 from exasol.slc.tool.options.flavor_options import flavor_options
@@ -80,7 +81,7 @@ def upload(
     use_job_specific_log_file: bool,
     ssl_cert_path: str,
     use_ssl_cert_validation: bool,
-    compression: bool,
+    compression_strategy: str,
 ):
     """
     This command uploads the whole script-language-container package of the flavor to the database.
@@ -123,7 +124,7 @@ def upload(
             use_job_specific_log_file=use_job_specific_log_file,
             ssl_cert_path=ssl_cert_path,
             use_ssl_cert_validation=use_ssl_cert_validation,
-            compression=compression,
+            compression_strategy=CompressionStrategy[compression_strategy.upper()],
         )
         with result.open("r") as f:
             print(f.read())

--- a/exasol/slc/tool/options/export_options.py
+++ b/exasol/slc/tool/options/export_options.py
@@ -1,0 +1,9 @@
+import click
+
+export_options = [
+    click.option(
+        "--compression/--no-compression",
+        default=True,
+        help="If set to --compression, a '.tar.gz' file will be created. Otherwise a '.tar' will be created.",
+    )
+]

--- a/exasol/slc/tool/options/export_options.py
+++ b/exasol/slc/tool/options/export_options.py
@@ -1,9 +1,17 @@
 import click
 
+from exasol.slc.models.compression_strategy import (
+    CompressionStrategy,
+    defaultCompressionStrategy,
+)
+
 export_options = [
     click.option(
-        "--compression/--no-compression",
-        default=True,
-        help="If set to --compression, a '.tar.gz' file will be created. Otherwise a '.tar' will be created.",
+        "--compression-strategy",
+        default=defaultCompressionStrategy().value,
+        type=click.Choice([v.value for v in CompressionStrategy]),
+        show_default=True,
+        help=f"Compression strategy to be applied to compress the exported container file."
+        f" Possible values are {[v.value for v in CompressionStrategy]}",
     )
 ]

--- a/test/test_docker_api_deploy.py
+++ b/test/test_docker_api_deploy.py
@@ -178,7 +178,7 @@ class ApiDockerDeployTest(unittest.TestCase):
             bucket_name,
             "",
             f"test-flavor-release-{release_name}.tar.gz",
-            compression=False,
+            compression=True,
         )
 
     def test_docker_api_deploy_fail_path_in_bucket(self):

--- a/test/test_docker_api_deploy.py
+++ b/test/test_docker_api_deploy.py
@@ -202,6 +202,36 @@ class ApiDockerDeployTest(unittest.TestCase):
             exception_thrown = True
         assert exception_thrown
 
+    # def check_file_in_bucketfs(
+    #     self,
+    #     url: str,
+    #     bucket_name: str,
+    #     bucketfs_username: str,
+    #     bucketfs_password: str,
+    #     path: str,
+    #     expected_file: str,
+    #     compression: bool,
+    # ):
+    #     CREDENTIALS = {
+    #         bucket_name: {"username": bucketfs_username, "password": bucketfs_password}
+    #     }
+    #
+    #     bucketfs = Service(url, CREDENTIALS)
+    #     bucket = bucketfs[bucket_name]
+    #
+    #     with TemporaryDirectory() as tmpdir:
+    #         file = as_file(
+    #             bucket.download(f"{path}/{expected_file}"),
+    #             filename=Path(tmpdir) / expected_file,
+    #         )
+    #
+    #         tar_mode = "r:gz" if compression else "r:"
+    #         with tarfile.open(name=file, mode=tar_mode) as tf:
+    #             tf_members = tf.getmembers()
+    #             last_tf_member = tf_members[-1]
+    #             assert last_tf_member.name == "exasol-manifest.json"
+    #             assert last_tf_member.path == "exasol-manifest.json"
+
     def check_file_in_bucketfs(
         self,
         host: str,

--- a/test/test_docker_api_deploy.py
+++ b/test/test_docker_api_deploy.py
@@ -1,6 +1,7 @@
 import subprocess
 import tarfile
 import unittest
+from functools import partial
 from tempfile import TemporaryDirectory
 
 import exasol.bucketfs as bfs  # type: ignore
@@ -29,13 +30,13 @@ class ApiDockerDeployTest(unittest.TestCase):
     def tearDown(self):
         utils.close_environments(self.test_environment, self.docker_environment)
 
-    def _validate_deploy(self, compression: bool, expected_extension: str):
-        path_in_bucket = "test"
+    def _validate_deploy(self, compression: bool, path: str, expected_extension: str):
         release_name = "TEST"
         bucketfs_name = "bfsdefault"
         bucket_name = "default"
         flavor_path = exaslct_utils.get_test_flavor()
-        result = api.deploy(
+        deploy_func = partial(
+            api.deploy,
             flavor_path=(str(flavor_path),),
             bucketfs_host=self.docker_environment.database_host,
             bucketfs_port=self.docker_environment.ports.bucketfs,
@@ -45,22 +46,37 @@ class ApiDockerDeployTest(unittest.TestCase):
             bucketfs_use_https=False,
             bucketfs_name=bucketfs_name,
             bucket=bucket_name,
-            path_in_bucket=path_in_bucket,
             release_name=release_name,
             compression=compression,
         )
+        if path:
+            result = deploy_func(path_in_bucket=path)
+        else:
+            result = deploy_func()
+
         self.assertIn(str(flavor_path), result.keys())
 
         self.assertEqual(len(result), 1)
         self.assertIn(str(flavor_path), result.keys())
         self.assertEqual(len(result[str(flavor_path)]), 1)
         deploy_result = result[str(flavor_path)]["release"]
-        expected_alter_session_cmd = (
-            f"ALTER SESSION SET SCRIPT_LANGUAGES='PYTHON3_TEST=localzmq+protobuf:///{bucketfs_name}/"
-            f"{bucket_name}/{path_in_bucket}/test-flavor-release-{release_name}?lang=python#buckets/"
-            f"{bucketfs_name}/{bucket_name}/{path_in_bucket}/test-flavor-release-{release_name}/"
-            f"exaudf/exaudfclient_py3';"
+
+        complete_path_in_bucket = "/".join(
+            filter(
+                None,
+                [
+                    bucketfs_name,
+                    bucket_name,
+                    path,
+                    f"test-flavor-release-{release_name}",
+                ],
+            )
         )
+        expected_alter_session_cmd = (
+            f"ALTER SESSION SET SCRIPT_LANGUAGES='PYTHON3_TEST=localzmq+protobuf:///{complete_path_in_bucket}?lang=python#buckets/"
+            f"{complete_path_in_bucket}/exaudf/exaudfclient_py3';"
+        )
+
         result_alter_session_cmd = (
             deploy_result.language_definition_builder.generate_alter_session()
         )
@@ -72,26 +88,43 @@ class ApiDockerDeployTest(unittest.TestCase):
             deploy_result.release_path,
         )
 
+        upload_path = "/".join(
+            filter(
+                None,
+                [
+                    bucket_name,
+                    path,
+                    f"test-flavor-release-{release_name}{expected_extension}",
+                ],
+            )
+        )
         self.assertEqual(
             deploy_result.human_readable_upload_location,
             f"http://{self.docker_environment.database_host}:{self.docker_environment.ports.bucketfs}/"
-            f"{bucket_name}/{path_in_bucket}/test-flavor-release-{release_name}{expected_extension}",
+            f"{upload_path}",
         )
 
-        expected_path_in_bucket = (
-            bfs.path.build_path(
-                backend=bfs.path.StorageBackend.onprem,
-                url=f"http://{self.docker_environment.database_host}:{self.docker_environment.ports.bucketfs}",
-                bucket_name=bucket_name,
-                service_name=bucketfs_name,
-                username="w",
-                password=self.docker_environment.bucketfs_password,
-                verify=False,
-                path=path_in_bucket,
+        build_path_func = partial(
+            bfs.path.build_path,
+            backend=bfs.path.StorageBackend.onprem,
+            url=f"http://{self.docker_environment.database_host}:{self.docker_environment.ports.bucketfs}",
+            bucket_name=bucket_name,
+            service_name=bucketfs_name,
+            username="w",
+            password=self.docker_environment.bucketfs_password,
+            verify=False,
+        )
+
+        if path:
+            expected_path_in_bucket = (
+                build_path_func(path=path)
+                / f"test-flavor-release-{release_name}{expected_extension}"
             )
-            / f"test-flavor-release-{release_name}{expected_extension}"
-        )
-
+        else:
+            expected_path_in_bucket = (
+                build_path_func()
+                / f"test-flavor-release-{release_name}{expected_extension}"
+            )
         # Compare UDF path of `bucket_path` until bfs.path.PathLike implements comparison
         self.assertEqual(
             expected_path_in_bucket.as_udf_path(),
@@ -100,85 +133,22 @@ class ApiDockerDeployTest(unittest.TestCase):
 
         self.validate_file_on_bucket_fs(
             bucket_name,
-            path_in_bucket,
+            path,
             f"test-flavor-release-{release_name}{expected_extension}",
             compression=compression,
         )
 
     def test_docker_api_deploy(self):
-        self._validate_deploy(compression=True, expected_extension=".tar.gz")
+        self._validate_deploy(
+            compression=True, path="test", expected_extension=".tar.gz"
+        )
 
     def test_docker_api_deploy_no_compression(self):
-        self._validate_deploy(compression=False, expected_extension=".tar")
+        self._validate_deploy(compression=False, path="test", expected_extension=".tar")
 
     def test_docker_api_deploy_without_path_in_bucket(self):
-        release_name = "TEST"
-        bucketfs_name = "bfsdefault"
-        bucket_name = "default"
-        flavor_path = exaslct_utils.get_test_flavor()
-        result = api.deploy(
-            flavor_path=(str(flavor_path),),
-            bucketfs_host=self.docker_environment.database_host,
-            bucketfs_port=self.docker_environment.ports.bucketfs,
-            bucketfs_user=self.docker_environment.bucketfs_username,
-            bucketfs_password=self.docker_environment.bucketfs_password,
-            target_docker_repository_name=self.test_environment.docker_repository_name,
-            bucketfs_use_https=False,
-            bucketfs_name=bucketfs_name,
-            bucket=bucket_name,
-            release_name=release_name,
-        )
-        self.assertIn(str(flavor_path), result.keys())
-        self.assertEqual(len(result), 1)
-        self.assertIn(str(flavor_path), result.keys())
-        self.assertEqual(len(result[str(flavor_path)]), 1)
-        deploy_result = result[str(flavor_path)]["release"]
-        expected_alter_session_cmd = (
-            f"ALTER SESSION SET SCRIPT_LANGUAGES='PYTHON3_TEST=localzmq+protobuf:///{bucketfs_name}/"
-            f"{bucket_name}/test-flavor-release-{release_name}?lang=python#buckets/"
-            f"{bucketfs_name}/{bucket_name}/test-flavor-release-{release_name}/"
-            f"exaudf/exaudfclient_py3';"
-        )
-        result_alter_session_cmd = (
-            deploy_result.language_definition_builder.generate_alter_session()
-        )
-        self.assertEqual(result_alter_session_cmd, expected_alter_session_cmd)
-
-        self.assertIn(
-            f".build_output/cache/exports/test-flavor-release-",
-            deploy_result.release_path,
-        )
-
-        self.assertEqual(
-            deploy_result.human_readable_upload_location,
-            f"http://{self.docker_environment.database_host}:{self.docker_environment.ports.bucketfs}/"
-            f"{bucket_name}/test-flavor-release-{release_name}.tar.gz",
-        )
-
-        expected_path_in_bucket = (
-            bfs.path.build_path(
-                backend=bfs.path.StorageBackend.onprem,
-                url=f"http://{self.docker_environment.database_host}:{self.docker_environment.ports.bucketfs}",
-                bucket_name=bucket_name,
-                service_name=bucketfs_name,
-                username="w",
-                password=self.docker_environment.bucketfs_password,
-                verify=False,
-            )
-            / f"test-flavor-release-{release_name}.tar.gz"
-        )
-
-        # Compare UDF path of `bucket_path` until bfs.path.PathLike implements comparison
-        self.assertEqual(
-            expected_path_in_bucket.as_udf_path(),
-            deploy_result.bucket_path.as_udf_path(),
-        )
-
-        self.validate_file_on_bucket_fs(
-            bucket_name,
-            "",
-            f"test-flavor-release-{release_name}.tar.gz",
-            compression=True,
+        self._validate_deploy(
+            compression=True, path="test", expected_extension=".tar.gz"
         )
 
     def test_docker_api_deploy_fail_path_in_bucket(self):
@@ -201,36 +171,6 @@ class ApiDockerDeployTest(unittest.TestCase):
         except TaskRuntimeError:
             exception_thrown = True
         assert exception_thrown
-
-    # def check_file_in_bucketfs(
-    #     self,
-    #     url: str,
-    #     bucket_name: str,
-    #     bucketfs_username: str,
-    #     bucketfs_password: str,
-    #     path: str,
-    #     expected_file: str,
-    #     compression: bool,
-    # ):
-    #     CREDENTIALS = {
-    #         bucket_name: {"username": bucketfs_username, "password": bucketfs_password}
-    #     }
-    #
-    #     bucketfs = Service(url, CREDENTIALS)
-    #     bucket = bucketfs[bucket_name]
-    #
-    #     with TemporaryDirectory() as tmpdir:
-    #         file = as_file(
-    #             bucket.download(f"{path}/{expected_file}"),
-    #             filename=Path(tmpdir) / expected_file,
-    #         )
-    #
-    #         tar_mode = "r:gz" if compression else "r:"
-    #         with tarfile.open(name=file, mode=tar_mode) as tf:
-    #             tf_members = tf.getmembers()
-    #             last_tf_member = tf_members[-1]
-    #             assert last_tf_member.name == "exasol-manifest.json"
-    #             assert last_tf_member.path == "exasol-manifest.json"
 
     def check_file_in_bucketfs(
         self,

--- a/test/test_docker_api_export.py
+++ b/test/test_docker_api_export.py
@@ -24,11 +24,70 @@ class ApiDockerExportTest(unittest.TestCase):
     def tearDown(self):
         utils.close_environments(self.test_environment)
 
-    def test_docker_export(self):
+    # def test_docker_export(self):
+    #     export_result = api.export(
+    #         flavor_path=(str(exaslct_utils.get_test_flavor()),),
+    #         export_path=self.export_path,
+    #         target_docker_repository_name=self.test_environment.docker_repository_name,
+    #     )
+    #     self.assertEqual(len(export_result.export_infos), 1)
+    #     export_infos_for_flavor = export_result.export_infos[
+    #         str(exaslct_utils.get_test_flavor())
+    #     ]
+    #     self.assertEqual(len(export_infos_for_flavor), 1)
+    #     export_info = export_infos_for_flavor["release"]
+    #     exported_files = os.listdir(self.export_path)
+    #     export_path = Path(export_info.output_file)
+    #     self.assertIn(export_path.name, exported_files)
+    #
+    #     # Verify that "exasol-manifest.json" is the last file in the Tar archive
+    #     with tarfile.open(export_path, "r:*") as tf:
+    #         tf_members = tf.getmembers()
+    #         last_tf_member = tf_members[-1]
+    #         assert last_tf_member.name == "exasol-manifest.json"
+    #         assert last_tf_member.path == "exasol-manifest.json"
+    #     images = find_images_by_tag(
+    #         self.docker_client,
+    #         lambda tag: tag.startswith(self.test_environment.docker_repository_name),
+    #     )
+    #     self.assertTrue(len(images) > 0, f"Images for repository were not found.")
+    #
+    # def test_docker_export_with_image_cleanup(self):
+    #     export_result = api.export(
+    #         flavor_path=(str(exaslct_utils.get_test_flavor()),),
+    #         export_path=self.export_path,
+    #         target_docker_repository_name=self.test_environment.docker_repository_name,
+    #         cleanup_docker_images=True,
+    #     )
+    #     self.assertEqual(len(export_result.export_infos), 1)
+    #     export_infos_for_flavor = export_result.export_infos[
+    #         str(exaslct_utils.get_test_flavor())
+    #     ]
+    #     self.assertEqual(len(export_infos_for_flavor), 1)
+    #     export_info = export_infos_for_flavor["release"]
+    #     exported_files = os.listdir(self.export_path)
+    #     export_path = Path(export_info.output_file)
+    #     self.assertIn(export_path.name, exported_files)
+    #
+    #     # Verify that "exasol-manifest.json" is the last file in the Tar archive
+    #     with tarfile.open(export_path, "r:*") as tf:
+    #         tf_members = tf.getmembers()
+    #         last_tf_member = tf_members[-1]
+    #         assert last_tf_member.name == "exasol-manifest.json"
+    #         assert last_tf_member.path == "exasol-manifest.json"
+    #
+    #     images = find_images_by_tag(
+    #         self.docker_client,
+    #         lambda tag: tag.startswith(self.test_environment.docker_repository_name),
+    #     )
+    #     self.assertTrue(len(images) == 0, f"Images for repository were not deleted. ")
+
+    def test_docker_export_uncompressed(self):
         export_result = api.export(
             flavor_path=(str(exaslct_utils.get_test_flavor()),),
             export_path=self.export_path,
             target_docker_repository_name=self.test_environment.docker_repository_name,
+            compression=False,
         )
         self.assertEqual(len(export_result.export_infos), 1)
         export_infos_for_flavor = export_result.export_infos[
@@ -39,6 +98,7 @@ class ApiDockerExportTest(unittest.TestCase):
         exported_files = os.listdir(self.export_path)
         export_path = Path(export_info.output_file)
         self.assertIn(export_path.name, exported_files)
+        self.assertEqual(export_path.suffix, ".tar")
 
         # Verify that "exasol-manifest.json" is the last file in the Tar archive
         with tarfile.open(export_path, "r:*") as tf:
@@ -51,36 +111,6 @@ class ApiDockerExportTest(unittest.TestCase):
             lambda tag: tag.startswith(self.test_environment.docker_repository_name),
         )
         self.assertTrue(len(images) > 0, f"Images for repository were not found.")
-
-    def test_docker_export_with_image_cleanup(self):
-        export_result = api.export(
-            flavor_path=(str(exaslct_utils.get_test_flavor()),),
-            export_path=self.export_path,
-            target_docker_repository_name=self.test_environment.docker_repository_name,
-            cleanup_docker_images=True,
-        )
-        self.assertEqual(len(export_result.export_infos), 1)
-        export_infos_for_flavor = export_result.export_infos[
-            str(exaslct_utils.get_test_flavor())
-        ]
-        self.assertEqual(len(export_infos_for_flavor), 1)
-        export_info = export_infos_for_flavor["release"]
-        exported_files = os.listdir(self.export_path)
-        export_path = Path(export_info.output_file)
-        self.assertIn(export_path.name, exported_files)
-
-        # Verify that "exasol-manifest.json" is the last file in the Tar archive
-        with tarfile.open(export_path, "r:*") as tf:
-            tf_members = tf.getmembers()
-            last_tf_member = tf_members[-1]
-            assert last_tf_member.name == "exasol-manifest.json"
-            assert last_tf_member.path == "exasol-manifest.json"
-
-        images = find_images_by_tag(
-            self.docker_client,
-            lambda tag: tag.startswith(self.test_environment.docker_repository_name),
-        )
-        self.assertTrue(len(images) == 0, f"Images for repository were not deleted. ")
 
 
 if __name__ == "__main__":

--- a/test/test_docker_api_export.py
+++ b/test/test_docker_api_export.py
@@ -24,63 +24,63 @@ class ApiDockerExportTest(unittest.TestCase):
     def tearDown(self):
         utils.close_environments(self.test_environment)
 
-    # def test_docker_export(self):
-    #     export_result = api.export(
-    #         flavor_path=(str(exaslct_utils.get_test_flavor()),),
-    #         export_path=self.export_path,
-    #         target_docker_repository_name=self.test_environment.docker_repository_name,
-    #     )
-    #     self.assertEqual(len(export_result.export_infos), 1)
-    #     export_infos_for_flavor = export_result.export_infos[
-    #         str(exaslct_utils.get_test_flavor())
-    #     ]
-    #     self.assertEqual(len(export_infos_for_flavor), 1)
-    #     export_info = export_infos_for_flavor["release"]
-    #     exported_files = os.listdir(self.export_path)
-    #     export_path = Path(export_info.output_file)
-    #     self.assertIn(export_path.name, exported_files)
-    #
-    #     # Verify that "exasol-manifest.json" is the last file in the Tar archive
-    #     with tarfile.open(export_path, "r:*") as tf:
-    #         tf_members = tf.getmembers()
-    #         last_tf_member = tf_members[-1]
-    #         assert last_tf_member.name == "exasol-manifest.json"
-    #         assert last_tf_member.path == "exasol-manifest.json"
-    #     images = find_images_by_tag(
-    #         self.docker_client,
-    #         lambda tag: tag.startswith(self.test_environment.docker_repository_name),
-    #     )
-    #     self.assertTrue(len(images) > 0, f"Images for repository were not found.")
-    #
-    # def test_docker_export_with_image_cleanup(self):
-    #     export_result = api.export(
-    #         flavor_path=(str(exaslct_utils.get_test_flavor()),),
-    #         export_path=self.export_path,
-    #         target_docker_repository_name=self.test_environment.docker_repository_name,
-    #         cleanup_docker_images=True,
-    #     )
-    #     self.assertEqual(len(export_result.export_infos), 1)
-    #     export_infos_for_flavor = export_result.export_infos[
-    #         str(exaslct_utils.get_test_flavor())
-    #     ]
-    #     self.assertEqual(len(export_infos_for_flavor), 1)
-    #     export_info = export_infos_for_flavor["release"]
-    #     exported_files = os.listdir(self.export_path)
-    #     export_path = Path(export_info.output_file)
-    #     self.assertIn(export_path.name, exported_files)
-    #
-    #     # Verify that "exasol-manifest.json" is the last file in the Tar archive
-    #     with tarfile.open(export_path, "r:*") as tf:
-    #         tf_members = tf.getmembers()
-    #         last_tf_member = tf_members[-1]
-    #         assert last_tf_member.name == "exasol-manifest.json"
-    #         assert last_tf_member.path == "exasol-manifest.json"
-    #
-    #     images = find_images_by_tag(
-    #         self.docker_client,
-    #         lambda tag: tag.startswith(self.test_environment.docker_repository_name),
-    #     )
-    #     self.assertTrue(len(images) == 0, f"Images for repository were not deleted. ")
+    def test_docker_export(self):
+        export_result = api.export(
+            flavor_path=(str(exaslct_utils.get_test_flavor()),),
+            export_path=self.export_path,
+            target_docker_repository_name=self.test_environment.docker_repository_name,
+        )
+        self.assertEqual(len(export_result.export_infos), 1)
+        export_infos_for_flavor = export_result.export_infos[
+            str(exaslct_utils.get_test_flavor())
+        ]
+        self.assertEqual(len(export_infos_for_flavor), 1)
+        export_info = export_infos_for_flavor["release"]
+        exported_files = os.listdir(self.export_path)
+        export_path = Path(export_info.output_file)
+        self.assertIn(export_path.name, exported_files)
+
+        # Verify that "exasol-manifest.json" is the last file in the Tar archive
+        with tarfile.open(export_path, "r:*") as tf:
+            tf_members = tf.getmembers()
+            last_tf_member = tf_members[-1]
+            assert last_tf_member.name == "exasol-manifest.json"
+            assert last_tf_member.path == "exasol-manifest.json"
+        images = find_images_by_tag(
+            self.docker_client,
+            lambda tag: tag.startswith(self.test_environment.docker_repository_name),
+        )
+        self.assertTrue(len(images) > 0, f"Images for repository were not found.")
+
+    def test_docker_export_with_image_cleanup(self):
+        export_result = api.export(
+            flavor_path=(str(exaslct_utils.get_test_flavor()),),
+            export_path=self.export_path,
+            target_docker_repository_name=self.test_environment.docker_repository_name,
+            cleanup_docker_images=True,
+        )
+        self.assertEqual(len(export_result.export_infos), 1)
+        export_infos_for_flavor = export_result.export_infos[
+            str(exaslct_utils.get_test_flavor())
+        ]
+        self.assertEqual(len(export_infos_for_flavor), 1)
+        export_info = export_infos_for_flavor["release"]
+        exported_files = os.listdir(self.export_path)
+        export_path = Path(export_info.output_file)
+        self.assertIn(export_path.name, exported_files)
+
+        # Verify that "exasol-manifest.json" is the last file in the Tar archive
+        with tarfile.open(export_path, "r:*") as tf:
+            tf_members = tf.getmembers()
+            last_tf_member = tf_members[-1]
+            assert last_tf_member.name == "exasol-manifest.json"
+            assert last_tf_member.path == "exasol-manifest.json"
+
+        images = find_images_by_tag(
+            self.docker_client,
+            lambda tag: tag.startswith(self.test_environment.docker_repository_name),
+        )
+        self.assertTrue(len(images) == 0, f"Images for repository were not deleted. ")
 
     def test_docker_export_uncompressed(self):
         export_result = api.export(

--- a/test/test_docker_api_export.py
+++ b/test/test_docker_api_export.py
@@ -9,6 +9,7 @@ from exasol_integration_test_docker_environment.testing import utils  # type: ig
 
 from exasol.slc import api
 from exasol.slc.internal.utils.docker_utils import find_images_by_tag
+from exasol.slc.models.compression_strategy import CompressionStrategy
 
 
 class ApiDockerExportTest(unittest.TestCase):
@@ -41,7 +42,7 @@ class ApiDockerExportTest(unittest.TestCase):
         self.assertIn(export_path.name, exported_files)
 
         # Verify that "exasol-manifest.json" is the last file in the Tar archive
-        with tarfile.open(export_path, "r:*") as tf:
+        with tarfile.open(export_path, "r:gz") as tf:
             tf_members = tf.getmembers()
             last_tf_member = tf_members[-1]
             assert last_tf_member.name == "exasol-manifest.json"
@@ -70,7 +71,7 @@ class ApiDockerExportTest(unittest.TestCase):
         self.assertIn(export_path.name, exported_files)
 
         # Verify that "exasol-manifest.json" is the last file in the Tar archive
-        with tarfile.open(export_path, "r:*") as tf:
+        with tarfile.open(export_path, "r:gz") as tf:
             tf_members = tf.getmembers()
             last_tf_member = tf_members[-1]
             assert last_tf_member.name == "exasol-manifest.json"
@@ -87,7 +88,7 @@ class ApiDockerExportTest(unittest.TestCase):
             flavor_path=(str(exaslct_utils.get_test_flavor()),),
             export_path=self.export_path,
             target_docker_repository_name=self.test_environment.docker_repository_name,
-            compression=False,
+            compression_strategy=CompressionStrategy.NONE,
         )
         self.assertEqual(len(export_result.export_infos), 1)
         export_infos_for_flavor = export_result.export_infos[
@@ -101,7 +102,7 @@ class ApiDockerExportTest(unittest.TestCase):
         self.assertEqual(export_path.suffix, ".tar")
 
         # Verify that "exasol-manifest.json" is the last file in the Tar archive
-        with tarfile.open(export_path, "r:*") as tf:
+        with tarfile.open(export_path, "r:") as tf:
             tf_members = tf.getmembers()
             last_tf_member = tf_members[-1]
             assert last_tf_member.name == "exasol-manifest.json"

--- a/test/test_docker_api_run_db_test_no_compression.py
+++ b/test/test_docker_api_run_db_test_no_compression.py
@@ -11,6 +11,7 @@ from exasol_integration_test_docker_environment.lib.models.data.environment_type
 from exasol_integration_test_docker_environment.testing import utils  # type: ignore
 
 from exasol.slc import api
+from exasol.slc.models.compression_strategy import CompressionStrategy
 
 
 class ApiDockerRunDbTestNoCompression(unittest.TestCase):
@@ -39,7 +40,7 @@ class ApiDockerRunDbTestNoCompression(unittest.TestCase):
             flavor_path=(str(exaslct_utils.get_test_flavor()),),
             test_container_folder=str(exaslct_utils.get_full_test_container_folder()),
             output_directory=self.test_environment.output_dir,
-            compression=False,
+            compression_strategy=CompressionStrategy.NONE,
             external_exasol_db_host=self.docker_environment.database_host,
             external_exasol_db_port=self.docker_environment.ports.database,
             external_exasol_db_user=self.docker_environment.db_username,

--- a/test/test_docker_api_run_db_test_no_compression.py
+++ b/test/test_docker_api_run_db_test_no_compression.py
@@ -1,0 +1,76 @@
+import unittest
+
+import docker
+import exasol.bucketfs as bfs
+import utils as exaslct_utils  # type: ignore # pylint: disable=import-error
+from exasol_integration_test_docker_environment.lib.models.data.environment_type import (
+    EnvironmentType,
+)
+from exasol_integration_test_docker_environment.testing import utils  # type: ignore
+
+from exasol.slc import api
+
+
+class ApiDockerRunDbTestNoCompression(unittest.TestCase):
+    #
+    # Spawn a
+    def setUp(self):
+        print(f"SetUp {self.__class__.__name__}")
+        self.test_environment = exaslct_utils.ExaslctApiTestEnvironmentWithCleanup(
+            self, True
+        )
+        self.export_path = self.test_environment.temp_dir + "/export_dir"
+        self.docker_client = docker.from_env()
+        self.test_environment.clean_all_images()
+        docker_environment_name = self.test_environment.name
+        self.docker_environment = self.test_environment.spawn_docker_test_environment(
+            docker_environment_name
+        )
+
+    def tearDown(self):
+        utils.close_environments(self.test_environment, self.docker_environment)
+
+    def _run_db_test(self):
+        api.run_db_test(
+            flavor_path=(str(exaslct_utils.get_test_flavor()),),
+            test_container_folder=str(exaslct_utils.get_full_test_container_folder()),
+            output_directory=self.test_environment.output_dir,
+            compression=False,
+            external_exasol_db_host=self.docker_environment.database_host,
+            external_exasol_db_port=self.docker_environment.ports.database,
+            external_exasol_db_user=self.docker_environment.db_username,
+            external_exasol_db_password=self.docker_environment.db_password,
+            external_exasol_bucketfs_port=self.docker_environment.ports.bucketfs,
+            external_exasol_bucketfs_write_password=self.docker_environment.bucketfs_password,
+            external_exasol_ssh_port=self.docker_environment.ports.ssh,
+            environment_type=EnvironmentType.external_db.name,
+        )
+
+    def validate_file_on_bucket_fs(self, expected_file_path: str):
+        host = self.docker_environment.database_host
+        port = self.docker_environment.ports.bucketfs
+        bucketfs_username = self.docker_environment.bucketfs_username
+        bucketfs_password = self.docker_environment.bucketfs_password
+        url = f"http://{host}:{port}"
+        udf_path = bfs.path.build_path(
+            backend=bfs.path.StorageBackend.onprem,
+            url=url,
+            bucket_name="myudfs",
+            service_name="bfsdefault",
+            username=bucketfs_username,
+            password=bucketfs_password,
+            verify=True,
+        )
+
+        container_files = [
+            file for file in udf_path.iterdir() if file.name == expected_file_path
+        ]
+        self.assertEqual(len(container_files), 1)
+
+    def test_run_db_test_no_compression(self):
+        self._run_db_test()
+        self.validate_file_on_bucket_fs(f"test-flavor.tar")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_docker_api_run_db_test_no_compression.py
+++ b/test/test_docker_api_run_db_test_no_compression.py
@@ -1,7 +1,9 @@
+import subprocess
+import tarfile
 import unittest
+from tempfile import TemporaryDirectory
 
 import docker
-import exasol.bucketfs as bfs
 import utils as exaslct_utils  # type: ignore # pylint: disable=import-error
 from exasol_integration_test_docker_environment.lib.models.data.environment_type import (
     EnvironmentType,
@@ -13,7 +15,9 @@ from exasol.slc import api
 
 class ApiDockerRunDbTestNoCompression(unittest.TestCase):
     #
-    # Spawn a
+    # Spawn a Docker db and run tests.
+    # The container will be exported and uploaded without compression.
+    #
     def setUp(self):
         print(f"SetUp {self.__class__.__name__}")
         self.test_environment = exaslct_utils.ExaslctApiTestEnvironmentWithCleanup(
@@ -46,26 +50,34 @@ class ApiDockerRunDbTestNoCompression(unittest.TestCase):
             environment_type=EnvironmentType.external_db.name,
         )
 
-    def validate_file_on_bucket_fs(self, expected_file_path: str):
+    def validate_file_on_bucket_fs(self, expected_file: str):
         host = self.docker_environment.database_host
         port = self.docker_environment.ports.bucketfs
         bucketfs_username = self.docker_environment.bucketfs_username
         bucketfs_password = self.docker_environment.bucketfs_password
-        url = f"http://{host}:{port}"
-        udf_path = bfs.path.build_path(
-            backend=bfs.path.StorageBackend.onprem,
-            url=url,
-            bucket_name="myudfs",
-            service_name="bfsdefault",
-            username=bucketfs_username,
-            password=bucketfs_password,
-            verify=True,
-        )
+        path_in_bucket = f"myudfs/{expected_file}"
+        with TemporaryDirectory() as tmpdir:
+            url = f"http://{bucketfs_username}:{bucketfs_password}@{host}:{port}/{path_in_bucket}"
+            file_name = f"{tmpdir}/{expected_file}"
+            cmd = [
+                "curl",
+                "--silent",
+                "--show-error",
+                "--fail",
+                url,
+                "--output",
+                file_name,
+            ]
+            p = subprocess.run(cmd, capture_output=True)
+            p.check_returncode()
 
-        container_files = [
-            file for file in udf_path.iterdir() if file.name == expected_file_path
-        ]
-        self.assertEqual(len(container_files), 1)
+            # "r:" makes 'tarfile.open' to raise an exception if file is not uncompressed tar format
+            tar_mode = "r:"
+            with tarfile.open(name=file_name, mode=tar_mode) as tf:  # type: ignore
+                tf_members = tf.getmembers()
+                last_tf_member = tf_members[-1]
+                assert last_tf_member.name == "exasol-manifest.json"
+                assert last_tf_member.path == "exasol-manifest.json"
 
     def test_run_db_test_no_compression(self):
         self._run_db_test()

--- a/test/test_docker_upload.py
+++ b/test/test_docker_upload.py
@@ -79,7 +79,7 @@ class DockerUploadTest(unittest.TestCase):
                 f"--path-in-bucket {self.path_in_bucket}",
                 f"--no-bucketfs-https",
                 f"--release-name {self.release_name}",
-                f"--no-compression",
+                f"--compression-strategy none",
             ]
         )
         command = f"{self.test_environment.executable} upload {arguments}"

--- a/test/test_docker_upload.py
+++ b/test/test_docker_upload.py
@@ -63,6 +63,41 @@ class DockerUploadTest(unittest.TestCase):
             f"{self.path_in_bucket}/test-flavor-release-{self.release_name}.tar.gz"
         )
 
+    def test_docker_upload_with_path_in_bucket_without_compression(self):
+        self.path_in_bucket = "test"
+        self.release_name = "TEST"
+        self.bucketfs_name = "bfsdefault"
+        self.bucket_name = "default"
+        arguments = " ".join(
+            [
+                f"--database-host {self.docker_environment.database_host}",
+                f"--bucketfs-port {self.docker_environment.ports.bucketfs}",
+                f"--bucketfs-username {self.docker_environment.bucketfs_username}",
+                f"--bucketfs-password {self.docker_environment.bucketfs_password}",
+                f"--bucketfs-name {self.bucketfs_name}",
+                f"--bucket-name {self.bucket_name}",
+                f"--path-in-bucket {self.path_in_bucket}",
+                f"--no-bucketfs-https",
+                f"--release-name {self.release_name}",
+                f"--no-compression",
+            ]
+        )
+        command = f"{self.test_environment.executable} upload {arguments}"
+
+        completed_process = self.test_environment.run_command(
+            command, track_task_dependencies=True, capture_output=True
+        )
+        self.assertIn(
+            f"ALTER SESSION SET SCRIPT_LANGUAGES='PYTHON3_TEST=localzmq+protobuf:///{self.bucketfs_name}/"
+            f"{self.bucket_name}/{self.path_in_bucket}/test-flavor-release-{self.release_name}?lang=python#buckets/"
+            f"{self.bucketfs_name}/{self.bucket_name}/{self.path_in_bucket}/test-flavor-release-{self.release_name}/"
+            f"exaudf/exaudfclient_py3",
+            completed_process.stdout.decode("UTF-8"),
+        )
+        self.validate_file_on_bucket_fs(
+            f"{self.path_in_bucket}/test-flavor-release-{self.release_name}.tar"
+        )
+
     def test_docker_upload_without_path_in_bucket(self):
         self.release_name = "TEST"
         self.bucketfs_name = "bfsdefault"

--- a/test/test_run_db_test_docker_db_no_compression.py
+++ b/test/test_run_db_test_docker_db_no_compression.py
@@ -1,0 +1,40 @@
+import unittest
+
+import utils as exaslct_utils  # type: ignore # pylint: disable=import-error
+from exasol_integration_test_docker_environment.lib.docker.container.utils import (
+    remove_docker_container,
+)
+
+
+class DockerRunDBTestDockerDBTestNoCompression(unittest.TestCase):
+
+    def setUp(self):
+        print(f"SetUp {self.__class__.__name__}")
+        self.test_environment = exaslct_utils.ExaslctTestEnvironmentWithCleanUp(
+            self, exaslct_utils.EXASLCT_DEFAULT_BIN
+        )
+        self.test_environment.clean_images()
+
+    def tearDown(self):
+        self.remove_docker_container()
+        self.test_environment.close()
+
+    def remove_docker_container(self):
+        remove_docker_container(
+            [
+                f"test_container_{self.test_environment.name}",
+                f"db_container_{self.test_environment.name}",
+            ]
+        )
+
+    def test_run_db_tests_docker_db(self):
+        command = (
+            f"{self.test_environment.executable} run-db-test "
+            f"{exaslct_utils.get_full_test_container_folder_parameter()}"
+            "--no-compression"
+        )
+        self.test_environment.run_command(command, track_task_dependencies=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_run_db_test_docker_db_no_compression.py
+++ b/test/test_run_db_test_docker_db_no_compression.py
@@ -58,7 +58,7 @@ class DockerRunDBTestDockerDBTestNoCompression(unittest.TestCase):
                 f"--external-exasol-db-user {self.docker_environment.db_username}",
                 f"--external-exasol-db-password {self.docker_environment.db_password}",
                 f"--external-exasol-bucketfs-write-password {self.docker_environment.bucketfs_password}",
-                f"--no-compression",
+                f"--compression-strategy none",
                 exaslct_utils.get_full_test_container_folder_parameter(),
             ]
         )

--- a/test/test_run_db_test_docker_db_no_compression.py
+++ b/test/test_run_db_test_docker_db_no_compression.py
@@ -1,9 +1,8 @@
 import unittest
 
+import exasol.bucketfs as bfs
 import utils as exaslct_utils  # type: ignore # pylint: disable=import-error
-from exasol_integration_test_docker_environment.lib.docker.container.utils import (
-    remove_docker_container,
-)
+from exasol_integration_test_docker_environment.testing import utils
 
 
 class DockerRunDBTestDockerDBTestNoCompression(unittest.TestCase):
@@ -13,27 +12,62 @@ class DockerRunDBTestDockerDBTestNoCompression(unittest.TestCase):
         self.test_environment = exaslct_utils.ExaslctTestEnvironmentWithCleanUp(
             self, exaslct_utils.EXASLCT_DEFAULT_BIN
         )
+        self.itde_test_environment = exaslct_utils.ExaslctApiTestEnvironmentWithCleanup(
+            self, False
+        )
         self.test_environment.clean_images()
+        self.docker_environment_name = self.__class__.__name__
+        self.docker_environment = (
+            self.itde_test_environment.spawn_docker_test_environment(
+                self.docker_environment_name
+            )
+        )
 
     def tearDown(self):
-        self.remove_docker_container()
-        self.test_environment.close()
+        utils.close_environments(self.docker_environment, self.test_environment)
 
-    def remove_docker_container(self):
-        remove_docker_container(
-            [
-                f"test_container_{self.test_environment.name}",
-                f"db_container_{self.test_environment.name}",
-            ]
+    def validate_file_on_bucket_fs(self, expected_file_path: str):
+        host = self.docker_environment.database_host
+        port = self.docker_environment.ports.bucketfs
+        bucketfs_username = self.docker_environment.bucketfs_username
+        bucketfs_password = self.docker_environment.bucketfs_password
+        url = f"http://{host}:{port}"
+        udf_path = bfs.path.build_path(
+            backend=bfs.path.StorageBackend.onprem,
+            url=url,
+            bucket_name="myudfs",
+            service_name="bfsdefault",
+            username=bucketfs_username,
+            password=bucketfs_password,
+            verify=True,
         )
+
+        container_files = [
+            file for file in udf_path.iterdir() if file.name == expected_file_path
+        ]
+        self.assertEqual(len(container_files), 1)
 
     def test_run_db_tests_docker_db(self):
-        command = (
-            f"{self.test_environment.executable} run-db-test "
-            f"{exaslct_utils.get_full_test_container_folder_parameter()}"
-            "--no-compression"
+        arguments = " ".join(
+            [
+                f"--environment-type external_db",
+                f"--external-exasol-db-host {self.docker_environment.database_host}",
+                f"--external-exasol-db-port {self.docker_environment.ports.database}",
+                f"--external-exasol-bucketfs-port {self.docker_environment.ports.bucketfs}",
+                f"--external-exasol-ssh-port {self.docker_environment.ports.ssh}",
+                f"--external-exasol-db-user {self.docker_environment.db_username}",
+                f"--external-exasol-db-password {self.docker_environment.db_password}",
+                f"--external-exasol-bucketfs-write-password {self.docker_environment.bucketfs_password}",
+                f"--no-compression",
+                exaslct_utils.get_full_test_container_folder_parameter(),
+            ]
         )
-        self.test_environment.run_command(command, track_task_dependencies=True)
+        self.test_environment.run_command(
+            f"{self.test_environment.executable} run-db-test {arguments}",
+            track_task_dependencies=True,
+        )
+
+        self.validate_file_on_bucket_fs(f"test-flavor.tar")
 
 
 if __name__ == "__main__":

--- a/test/unit/cli/test_deploy.py
+++ b/test/unit/cli/test_deploy.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
+from exasol.slc.models.compression_strategy import defaultCompressionStrategy
 from exasol.slc.models.deploy_result import DeployResult
 from exasol.slc.models.language_definition_components import (
     BuiltInLanguageDefinitionURL,
@@ -115,6 +116,7 @@ def test_deploy_minimum_parameters(cli):
             use_job_specific_log_file=True,
             ssl_cert_path="",
             use_ssl_cert_validation=True,
+            compression_strategy=defaultCompressionStrategy(),
         )
 
 
@@ -191,4 +193,5 @@ def test_deploy_password_in_env(cli):
             use_job_specific_log_file=True,
             ssl_cert_path="",
             use_ssl_cert_validation=True,
+            compression_strategy=defaultCompressionStrategy(),
         )


### PR DESCRIPTION
fixes #277 

also reactivates unit tests in CI which were removed from [checks.yml](https://github.com/exasol/script-languages-container-tool/blob/main/.github/workflows/checks.yml) in #255 .