### PR TITLE
Fixed problems with `run-db-test`

### DIFF
--- a/doc/changes/unreleased.md
+++ b/doc/changes/unreleased.md
@@ -1,1 +1,5 @@
 # Unreleased
+
+## Bugs
+ - #284: Fixed problem with `run-db-test` integration test `test_run_db_test_docker_credentials`
+ - #285: Fixed problem with `run-db-test` option -`-test-file`

--- a/exasol/slc/internal/tasks/test/run_db_test_files.py
+++ b/exasol/slc/internal/tasks/test/run_db_test_files.py
@@ -1,5 +1,5 @@
 # pylint: disable=not-an-iterable
-from typing import Any, Generator, Tuple
+from typing import Any, Generator, Optional, Tuple
 
 from exasol_integration_test_docker_environment.lib.base.base_task import BaseTask
 from exasol_integration_test_docker_environment.lib.base.flavor_task import (
@@ -37,16 +37,15 @@ class RunDBTestFiles(
     def run_task(self) -> Generator[BaseTask, None, None]:
         results = []
         for language in self.languages:
-            if language is not None:
-                results_for_language = []
-                for test_file in self.test_files:
-                    test_result = yield from self.run_test(language, test_file)
-                    results_for_language.append(test_result)
-                results.append(
-                    RunDBTestCollectionResult(
-                        language=language, test_results=results_for_language
-                    )
+            results_for_language = []
+            for test_file in self.test_files:
+                test_result = yield from self.run_test(language, test_file)
+                results_for_language.append(test_result)
+            results.append(
+                RunDBTestCollectionResult(
+                    language=language, test_results=results_for_language
                 )
+            )
         test_results = RunDBTestFilesResult(test_results=results)
         JsonPickleTarget(self.get_output_path().joinpath("test_results.json")).write(
             test_results, 4
@@ -54,7 +53,7 @@ class RunDBTestFiles(
         self.return_object(test_results)
 
     def run_test(
-        self, language: str, test_file: str
+        self, language: Optional[str], test_file: str
     ) -> Generator[RunDBTest, Any, RunDBTestResult]:
         task = self.create_child_task_with_common_params(
             RunDBTest,

--- a/exasol/slc/models/run_db_test_result.py
+++ b/exasol/slc/models/run_db_test_result.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 
 class RunDBTestResult:
@@ -13,7 +13,9 @@ class RunDBTestResult:
 
 
 class RunDBTestCollectionResult:
-    def __init__(self, language: str, test_results: List[RunDBTestResult]) -> None:
+    def __init__(
+        self, language: Optional[str], test_results: List[RunDBTestResult]
+    ) -> None:
         self.language = language
         self.test_results = test_results
         self.tests_are_ok = all(test_result.is_ok for test_result in test_results)

--- a/test/test_docker_api_run_db_test_single_file.py
+++ b/test/test_docker_api_run_db_test_single_file.py
@@ -14,7 +14,7 @@ from exasol.slc import api
 from exasol.slc.models.compression_strategy import CompressionStrategy
 
 
-class ApiDockerRunDbTestNoCompression(unittest.TestCase):
+class ApiDockerRunDbTestSingleFile(unittest.TestCase):
     #
     # Spawn a Docker db and run test for single file.
     #

--- a/test/test_docker_api_run_db_test_single_file.py
+++ b/test/test_docker_api_run_db_test_single_file.py
@@ -23,7 +23,6 @@ class ApiDockerRunDbTestSingleFile(unittest.TestCase):
         self.test_environment = exaslct_utils.ExaslctApiTestEnvironmentWithCleanup(
             self, True
         )
-        self.export_path = self.test_environment.temp_dir + "/export_dir"
         self.test_environment.clean_all_images()
 
     def tearDown(self):

--- a/test/test_docker_api_run_db_test_single_file.py
+++ b/test/test_docker_api_run_db_test_single_file.py
@@ -1,0 +1,58 @@
+import subprocess
+import tarfile
+import unittest
+from tempfile import TemporaryDirectory
+
+import docker
+import utils as exaslct_utils  # type: ignore # pylint: disable=import-error
+from exasol_integration_test_docker_environment.lib.models.data.environment_type import (
+    EnvironmentType,
+)
+from exasol_integration_test_docker_environment.testing import utils  # type: ignore
+
+from exasol.slc import api
+from exasol.slc.models.compression_strategy import CompressionStrategy
+
+
+class ApiDockerRunDbTestNoCompression(unittest.TestCase):
+    #
+    # Spawn a Docker db and run test for single file.
+    #
+    def setUp(self):
+        print(f"SetUp {self.__class__.__name__}")
+        self.test_environment = exaslct_utils.ExaslctApiTestEnvironmentWithCleanup(
+            self, True
+        )
+        self.export_path = self.test_environment.temp_dir + "/export_dir"
+        self.test_environment.clean_all_images()
+
+    def tearDown(self):
+        utils.close_environments(self.test_environment)
+
+    def test_run_db_test_single_file(self):
+        result = api.run_db_test(
+            flavor_path=(str(exaslct_utils.get_test_flavor()),),
+            test_container_folder=str(exaslct_utils.get_full_test_container_folder()),
+            output_directory=self.test_environment.output_dir,
+            test_file=("empty_test.py",),
+        )
+        flavor_keys = list(result.test_results_per_flavor.keys())
+        self.assertEqual(len(flavor_keys), 1)
+        flavor_key = flavor_keys[0]
+
+        test_result_per_flavor = result.test_results_per_flavor[flavor_key]
+        test_result_per_release = test_result_per_flavor.test_results_per_release_goal[
+            "release"
+        ]
+        test_file_output = test_result_per_release.test_files_output
+        self.assertEqual(len(test_file_output.test_results), 1)
+        test_results = test_file_output.test_results[0]
+        self.assertEqual(len(test_results.test_results), 1)
+        test_result = test_results.test_results[0]
+        self.assertEqual(test_result.test_file, "empty_test.py")
+        self.assertEqual(test_result.language, "None")
+        self.assertTrue(test_result.is_ok)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_run_db_test_docker_credentials.py
+++ b/test/test_run_db_test_docker_credentials.py
@@ -18,7 +18,7 @@ class RunDBTestDockerCredentials(unittest.TestCase):
         utils.close_environments(self.test_environment)
 
     @unittest.skipIf(
-        os.getenv("DOCKER_USER") is not None and os.getenv("DOCKER_PASSWD") is not None,
+        os.getenv("DOCKER_USER") is None or os.getenv("DOCKER_PASSWD") is None,
         "Docker credentials not configured",
     )
     def test_docker_credentials_injection_into_test_container(self):


### PR DESCRIPTION
#284: Fixed problem with `run-db-test` integration test `test_run_db_test_docker_credentials`
#285: Fixed problem with `run-db-test` option -`-test-file`

fixes #284 
fixes #285 