### PR TITLE
Update README to pass twine inspection

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -165,7 +165,7 @@ to the following one:
 
    ALTER SESSION SET SCRIPT_LANGUAGES='<LANGUAGE_ALIAS>=localzmq+protobuf:///<bucketfs-name>/<bucket-name>/<path-in-bucket>/<container-name>?lang=<language>#buckets/<bucketfs-name>/<bucket-name>/<path-in-bucket>/<container-name>/exaudf/exaudfclient[_py3]';
 
-**Please, refer to the** :doc:`User Guide <user_guide/user_guide>`.
+**Please, refer to the** `User Guide <https://exasol.github.io/script-languages-container-tool/main/user_guide/user_guide.html>`__.
 **for more detailed information, how to use exalsct.**
 
 Features

--- a/doc/changes/changes_3.4.0.md
+++ b/doc/changes/changes_3.4.0.md
@@ -6,9 +6,13 @@
 
 ## Refactorings
 
- - #301: Update PTB and workflows and activate generation of GH pages
+ - #301: Updated PTB and workflows and activate generation of GH pages
  - #305: Updated exasol-bucketfs to 2.0.0
 
 ## Security
 
- - #303: Update dependencies on top of 3.3.0, including exasol-toolbox to 1.6.0
+ - #303: Updated dependencies on top of 3.3.0, including exasol-toolbox to 1.6.0
+
+## Bugfixes
+
+ - Changed referenced link to external link in README due to issues with PyPi & GitHub rendering


### PR DESCRIPTION
When trying to release 3.4.0 in https://github.com/exasol/script-languages-container-tool/actions/runs/16167250989/job/45631954286, we ran into issues:

![image](https://github.com/user-attachments/assets/67554e01-dc72-4818-ac54-b20e54aef56b)

To resolve these issues, I ran:
```bash
# to create the build files
poetry build
# to analyze the build files 
poetry run -- twine check ./dist/*

Checking ./dist/exasol_script_languages_container_tool-3.4.0-py3-none-any.whl: FAILED
ERROR    `long_description` has syntax errors in markup and would not be rendered on PyPI.                                                                                                         
         line 168: Error: Unknown interpreted text role "doc".                                                                                                                                     
Checking ./dist/exasol_script_languages_container_tool-3.4.0.tar.gz: FAILED
ERROR    `long_description` has syntax errors in markup and would not be rendered on PyPI.                                                                                                         
         line 168: Error: Unknown interpreted text role "doc". 
```
Thus, I replaced it with an external link to our user guide.

While :doc: and :ref: render well with sphinx, it doesn't do well with PyPi  or GitHub.